### PR TITLE
Buildbot windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,3 @@ install:
 
 script:
   - 'pipenv run pytest tests'
-#  - 'cd Scripts && pipenv run pytest tests'
-#  - 'cd Scripts && python -m pytest --cov=pyblizzard tests --cov-report=xml'
-#after_success:
-#  - 'python-codacy-coverage -r coverage.xml'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
-language: python
-
+language: sh
 os: windows
 
-python:
-  - '2.7'
+#python:
+#  - '2.7'
 
 env:
   global:
@@ -14,7 +13,7 @@ env:
 before_install:
   - choco install python2
   - python -m pip install --upgrade pip
-  
+
 install:
   - 'pip install pipenv'
   - 'cd Scripts && pipenv --python 2.7 install --dev'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: python
+
+python:
+  - '2.7'
+
+env:
+  global:
+    # Our .env file uses Windows-specific commands so we need to override it
+    - PIPENV_DOTENV_LOCATION=".env-nix"
+
+install:
+  - 'pip install pipenv'
+  - 'cd Scripts && pipenv --python 2.7 install --dev'
+
+script:
+  - 'pipenv run pytest tests'
+#  - 'cd Scripts && pipenv run pytest tests'
+#  - 'cd Scripts && python -m pytest --cov=pyblizzard tests --cov-report=xml'
+#after_success:
+#  - 'python-codacy-coverage -r coverage.xml'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,8 @@
-language: sh
+language: sh # 'language: python' is not yet supported on Windows
 os: windows
-
-#python:
-#  - '2.7'
 
 env:
   global:
-    # Our .env file uses Windows-specific commands so we need to override it
-    #- PIPENV_DOTENV_LOCATION=".env-nix"
     - PATH=/c/Python27:/c/Python27/Scripts:$PATH
 
 before_install:
@@ -15,8 +10,10 @@ before_install:
   - python -m pip install --upgrade pip
 
 install:
-  - 'pip install pipenv'
-  - 'cd Scripts && pipenv --python 2.7 install --dev'
+  - pip install pipenv
+  - cd Scripts
+  - pipenv --python 2.7 install --dev
 
 script:
-  - 'pipenv run pytest tests'
+  - pipenv run pytest tests
+  - pipenv run python app.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,20 @@
 language: python
 
+os: windows
+
 python:
   - '2.7'
 
 env:
   global:
     # Our .env file uses Windows-specific commands so we need to override it
-    - PIPENV_DOTENV_LOCATION=".env-nix"
+    #- PIPENV_DOTENV_LOCATION=".env-nix"
+    - PATH=/c/Python27:/c/Python27/Scripts:$PATH
 
+before_install:
+  - choco install python2
+  - python -m pip install --upgrade pip
+  
 install:
   - 'pip install pipenv'
   - 'cd Scripts && pipenv --python 2.7 install --dev'

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Build Status](https://travis-ci.org/HSLdevcom/helmet-model-system.svg?branch=master)](https://travis-ci.org/HSLdevcom/helmet-model-system)
+
+
 # helmet-model-system
 
 This repository contains python files for Helmet 4.0 Model System. Source codes can be found in the [Scripts-folder](Scripts).
@@ -13,7 +16,7 @@ Also the final prodution version is always run on Windows because EMME only supp
 
 ### Dependencies
 
-We have several external dependencies in our codebase, f.ex NumPy and OMX, etc. Reason for including them to this repository is because the version of the OMX-library used by EMME is highly custom and cannot be found from normal PyPi repositories. 
+We have several external dependencies in our codebase, f.ex NumPy and OMX, etc. Reason for including them to this repository is because the version of the OMX-library used by EMME is highly custom and cannot be found from normal PyPi repositories.
 
 Importing the dependencies depend on the environment (local-development or production). In production-mode they come via EMME and in development we use PipEnv.
 
@@ -30,7 +33,7 @@ At the moment user is not expected to install any software, other than the provi
 In the development setup we're using two approaches to import the libraries:
 
 - part of the libraries are included as static depencies and are located in [./Scripts/pythonlibs/ folder](./Scripts/pythonlibs/). This is because they don't install very nicely from PyPi-public repositories.
-  - When developing locally you need to import the libraries to PYTHONPATH. 
+  - When developing locally you need to import the libraries to PYTHONPATH.
     - This can happen either by using the script [import-dev-dependencies.bat](./Scripts/import-dev-dependencies.bat)
 	- OR by using pipenv, which then loads the PYTHONPATH via the [.env file](./Scripts/.env)
 - Other more compatible libraries are installed via *pipenv*. Pipenv isolates our environment from the other global python modules and makes sure we don't break anything else with our setup.   
@@ -53,7 +56,7 @@ pip install --user pipenv
 
 ```   
 # First setup:
-pipenv --python 2.7 install --dev 
+pipenv --python 2.7 install --dev
 # Once setup is done you can just run
 pipenv --python 2.7 sync --dev
 ```

--- a/Scripts/.env-nix
+++ b/Scripts/.env-nix
@@ -1,0 +1,1 @@
+PYTHONPATH=.:./pythonlibs/

--- a/Scripts/tests/test_imports.py
+++ b/Scripts/tests/test_imports.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+
+
+import unittest
+import numpy
+import pandas
+import omx
+
+class ImportTest(unittest.TestCase):
+    def test_imports(self):
+        self.assertIsNotNone(numpy.__version__)
+        self.assertIsNotNone(pandas.__version__)
+        self.assertIsNotNone(omx.__version__)


### PR DESCRIPTION
Setup for Travis-buildbot which is integrated to Github. Every time we push anything to any branch in this repository, Travis will run our tests automatically and report via email if any of them fails.

Now this runs on Windows so we can run full tests, including app.py!

status and build logs are here: https://travis-ci.org/HSLdevcom/helmet-model-system

link to build logs is also on Readme, by clicking on the icon.

At the moment each build takes about 3,5 minutes.