### PR TITLE
Feat/sec dest optimization

### DIFF
--- a/Scripts/datatypes/purpose.py
+++ b/Scripts/datatypes/purpose.py
@@ -246,14 +246,14 @@ class SecDestPurpose(Purpose):
         """
         dest_imp = {}
         for mtx_type in impedance:
-            dest_imp[mtx_type] = ( impedance[mtx_type][self.bounds, :]
+            dest_imp[mtx_type] = ( impedance[mtx_type]
                                  + impedance[mtx_type][:, origin]
-                                 - impedance[mtx_type][origin, self.bounds][:, numpy.newaxis])
+                                 - impedance[mtx_type][origin, :][:, numpy.newaxis])
         # TODO Make origin distinction between impedance matrix and lookup
         # In peripheral area these would not be the same
         prob = self.model.calc_prob(mode, dest_imp, origin)
         demand = (prob * self.tours[mode][origin, :]).T
-        self.attracted_tours[mode] += demand.sum(0)
+        self.attracted_tours[mode][self.bounds] += demand.sum(0)
         return Demand(self, mode, demand, origin)
 
     def calc_prob(self, mode, impedance, position):

--- a/Scripts/datatypes/purpose.py
+++ b/Scripts/datatypes/purpose.py
@@ -117,7 +117,7 @@ class TourPurpose(Purpose):
         self.demand_sums = {}
         self.trip_lengths = {}
         for mode in self.model.mode_choice_param:
-            mtx = (self.prob[mode] * tours).T
+            mtx = (self.prob.pop(mode) * tours).T
             try:
                 self.sec_dest_purpose.gen_model.add_tours(mtx, mode, self)
             except AttributeError:

--- a/Scripts/datatypes/purpose.py
+++ b/Scripts/datatypes/purpose.py
@@ -207,16 +207,15 @@ class SecDestPurpose(Purpose):
 
     def init_sums(self):
         for mode in self.model.dest_choice_param:
-            self.generated_tours[mode] = numpy.zeros_like(next(iter(self.sources)).zone_numbers)
-            self.attracted_tours[mode] = numpy.zeros_like(self.zone_numbers)
+            self.generated_tours[mode] = 0
+            self.attracted_tours[mode] = numpy.zeros_like(self.zone_data.zone_numbers, float)
 
     def generate_tours(self):
         """Generate the source tours without secondary destinations."""
         self.tours = {}
+        self.init_sums()
         for mode in self.model.dest_choice_param:
             self.tours[mode] = self.gen_model.generate_tours(mode)
-            self.attracted_tours[mode] = self.tours[mode].sum(0)
-            self.generated_tours[mode] = self.tours[mode].sum(1)
 
     def distribute_tours(self, mode, impedance, origin):
         """Decide the secondary destination for all tours (generated 
@@ -239,9 +238,9 @@ class SecDestPurpose(Purpose):
         """
         dest_imp = {}
         for mtx_type in impedance:
-            dest_imp[mtx_type] = ( impedance[mtx_type]
+            dest_imp[mtx_type] = ( impedance[mtx_type][self.bounds, :]
                                  + impedance[mtx_type][:, origin]
-                                 - impedance[mtx_type][origin, :][:, numpy.newaxis])
+                                 - impedance[mtx_type][origin, self.bounds][:, numpy.newaxis])
         # TODO Make origin distinction between impedance matrix and lookup
         # In peripheral area these would not be the same
         prob = self.model.calc_prob(mode, dest_imp, origin)

--- a/Scripts/datatypes/purpose.py
+++ b/Scripts/datatypes/purpose.py
@@ -52,7 +52,7 @@ class Purpose:
         return self.zone_data.zone_numbers[self.bounds]
 
 class TourPurpose(Purpose):
-    def __init__(self, specification, zone_data):
+    def __init__(self, specification, zone_data, is_agent_model):
         """Standard two-way tour purpose.
 
         Parameters
@@ -75,11 +75,11 @@ class TourPurpose(Purpose):
         else:
             self.gen_model = generation.GenerationModel(self)
         if self.name == "sop":
-            self.model = logit.OriginModel(zone_data, self)
+            self.model = logit.OriginModel(zone_data, self, is_agent_model)
         elif self.name == "so":
-            self.model = logit.DestModeModel(zone_data, self)
+            self.model = logit.DestModeModel(zone_data, self, is_agent_model)
         else:
-            self.model = logit.ModeDestModel(zone_data, self)
+            self.model = logit.ModeDestModel(zone_data, self, is_agent_model)
         self.modes = self.model.mode_choice_param.keys()
         self.sec_dest_purpose = None
 
@@ -191,7 +191,7 @@ class TourPurpose(Purpose):
 
 
 class SecDestPurpose(Purpose):
-    def __init__(self, specification, zone_data):
+    def __init__(self, specification, zone_data, is_agent_model):
         """Purpose for secondary destination of tour.
 
         Parameters
@@ -210,7 +210,7 @@ class SecDestPurpose(Purpose):
         """
         Purpose.__init__(self, specification, zone_data)
         self.gen_model = generation.SecDestGeneration(self)
-        self.model = logit.SecDestModel(zone_data, self)
+        self.model = logit.SecDestModel(zone_data, self, is_agent_model)
         self.modes = self.model.dest_choice_param.keys()
 
     def init_sums(self):

--- a/Scripts/datatypes/tour.py
+++ b/Scripts/datatypes/tour.py
@@ -61,7 +61,7 @@ class Tour:
         if self.mode != "walk" and is_in_area and random.random() < self.sec_dest_prob:
             probs = self.purpose.sec_dest_purpose.calc_prob(
                 self.mode, impedance[self.mode], self.position)
-            self.sec_dest = numpy.random.choice(a=zone_numbers, p=probs)
+            self.sec_dest = numpy.random.choice(a=self.purpose.zone_numbers, p=probs)
             self.purpose.sec_dest_purpose.attracted_tours[self.mode][self.position[2]] += 1
         else:
             self.sec_dest = None

--- a/Scripts/datatypes/tour.py
+++ b/Scripts/datatypes/tour.py
@@ -20,13 +20,9 @@ class Tour:
         self.sec_dest = None
         self.matrix = 1 # So far, one person per tour
         try:
-            sec_dest_prob = purpose.sec_dest_purpose.gen_model.param[purpose.name]
+            self.sec_dest_prob = purpose.sec_dest_purpose.gen_model.param[purpose.name]
         except AttributeError:
-            sec_dest_prob = 0
-        if random.random() < sec_dest_prob:
-            self.has_sec_dest = True
-        else:
-            self.has_sec_dest = False
+            self.sec_dest_prob = 0
     
     @property
     def position(self):
@@ -52,7 +48,14 @@ class Tour:
         probs = self.purpose.model.dest_prob[self.mode][:, self.position[0]]
         self.dest = numpy.random.choice(a=zone_numbers, p=probs)
         self.purpose.attracted_tours[self.mode][self.position[1]] += 1
-        if self.has_sec_dest and self.mode != "walk":
+        try:
+            if self.position[1] < self.purpose.sec_dest_purpose.bounds.stop:
+                is_in_area = True
+            else:
+                is_in_area = False
+        except AttributeError:
+            is_in_area = False
+        if self.mode != "walk" and is_in_area and random.random() < self.sec_dest_prob:
             probs = self.purpose.sec_dest_purpose.calc_prob(
                 self.mode, impedance[self.mode], self.position)
             self.sec_dest = numpy.random.choice(a=zone_numbers, p=probs)

--- a/Scripts/demand/trips.py
+++ b/Scripts/demand/trips.py
@@ -10,7 +10,7 @@ import datahandling.resultdata as result
 
 
 class DemandModel:
-    def __init__(self, zone_data):
+    def __init__(self, zone_data, is_agent_model=False):
         """Container for private tour purposes and models.
 
         Parameters
@@ -23,9 +23,9 @@ class DemandModel:
         self.purpose_dict = {}
         for purpose_spec in parameters.tour_purposes:
             if "sec_dest" in purpose_spec:
-                purpose = SecDestPurpose(purpose_spec, zone_data)
+                purpose = SecDestPurpose(purpose_spec, zone_data, is_agent_model)
             else:
-                purpose = TourPurpose(purpose_spec, zone_data)
+                purpose = TourPurpose(purpose_spec, zone_data, is_agent_model)
             self.tour_purposes.append(purpose)
             self.purpose_dict[purpose_spec["name"]] = purpose
         for purpose_spec in parameters.tour_purposes:

--- a/Scripts/models/logit.py
+++ b/Scripts/models/logit.py
@@ -6,7 +6,7 @@ import datahandling.resultdata as result
 
 
 class LogitModel:
-    def __init__(self, zone_data, purpose):
+    def __init__(self, zone_data, purpose, is_agent_model):
         self.purpose = purpose
         self.bounds = purpose.bounds
         self.zone_data = zone_data
@@ -14,11 +14,13 @@ class LogitModel:
         self.mode_exps = {}
         self.dest_choice_param = parameters.destination_choice[purpose.name]
         self.mode_choice_param = parameters.mode_choice[purpose.name]
+        if is_agent_model:
+            self.dtype = float
+        else:
+            self.dtype = None
 
     def _calc_mode_util(self, impedance):
-        # Impedances from omx are float32, here we use float64 to make
-        # numpy random choice for agents work. Memory issue?
-        expsum = numpy.zeros_like(next(iter(impedance["car"].values())), float)
+        expsum = numpy.zeros_like(next(iter(impedance["car"].values())), self.dtype)
         for mode in self.mode_choice_param:
             b = self.mode_choice_param[mode]
             utility = numpy.zeros_like(expsum)
@@ -35,7 +37,7 @@ class LogitModel:
     
     def _calc_dest_util(self, mode, impedance):
         b = self.dest_choice_param[mode]
-        utility = numpy.zeros_like(next(iter(impedance.values())), float)
+        utility = numpy.zeros_like(next(iter(impedance.values())), self.dtype)
         self._add_zone_util(utility, b["attraction"])
         self._add_impedance(utility, impedance, b["impedance"])
         self.dest_exps[mode] = numpy.exp(utility)
@@ -59,7 +61,7 @@ class LogitModel:
     
     def _calc_sec_dest_util(self, mode, impedance, orig, dest):
         b = self.dest_choice_param[mode]
-        utility = numpy.zeros_like(next(iter(impedance.values())), float)
+        utility = numpy.zeros_like(next(iter(impedance.values())), self.dtype)
         self._add_sec_zone_util(utility, b["attraction"], orig, dest)
         self._add_impedance(utility, impedance, b["impedance"])
         self.dest_exps[mode] = numpy.exp(utility)

--- a/Scripts/models/logit.py
+++ b/Scripts/models/logit.py
@@ -144,12 +144,8 @@ class LogitModel:
                 utility += b[i] * data
             except ValueError: # Separate params for orig and dest
                 u = self.zone_data.first_peripheral_zone
-                if utility.ndim == 1: # 1-d array calculation
-                    utility += b[i][0] * data[orig, :u]
-                    utility += b[i][1] * data[dest, :u]
-                else: # 2-d matrix calculation
-                    utility += b[i][0] * data[orig, :u]
-                    utility += b[i][1] * data[:, :u]
+                utility += b[i][0] * data[orig, :u]
+                utility += b[i][1] * data[dest, :u]
         return utility
 
     def _add_log_zone_util(self, exps, b, generation=False):

--- a/Scripts/models/logit.py
+++ b/Scripts/models/logit.py
@@ -114,7 +114,7 @@ class LogitModel:
                         utility[k:] += b[i][1] * data_surrounding
                     else:
                         utility += b[i][0] * zdata.get_data(
-                            i, self.bounds, generation)[:, orig]
+                            i, self.bounds, generation)[orig, :]
                         utility += b[i][1] * zdata.get_data(
                             i, self.bounds, generation)[dest, :]
                 else: # 2-d matrix calculation
@@ -123,7 +123,7 @@ class LogitModel:
                         utility[k:, :] += b[i][1] * data_surrounding
                     else:
                         utility += b[i][0] * zdata.get_data(
-                            i, self.bounds, generation)[:, orig]
+                            i, self.bounds, generation)[orig, :]
                         utility += b[i][1] * zdata.get_data(
                             i, self.bounds, generation)
         return utility

--- a/Scripts/modelsystem.py
+++ b/Scripts/modelsystem.py
@@ -20,11 +20,12 @@ class ModelSystem:
         self.zdata_forecast = ZoneData(zone_data_path, ass_model.zone_numbers)
         self.basematrices = MatrixData(base_matrices)
         self.resultmatrices = MatrixData(name)
-        self.dm = DemandModel(self.zdata_forecast)
         self.is_agent_model = is_agent_model
         if is_agent_model:
+            self.dm = DemandModel(self.zdata_forecast, is_agent_model)
             self.dm.create_population()
         else:
+            self.dm = DemandModel(self.zdata_forecast)
             self.dm.create_population_segments()
         self.fm = FreightModel(self.zdata_base,
                                self.zdata_forecast,

--- a/Scripts/parameters.py
+++ b/Scripts/parameters.py
@@ -737,20 +737,23 @@ impedance_share = {
         },
     },
     "hoo": {
+        # Only un-transposed afternoon matrices are used.
+        # However, the secondary destination choice is done "backwards",
+        # from destination 1 to origin.
         "car": {
             "aht": (0, 0),
             "pt":  (0, 0),
-            "iht": (0, 1),
+            "iht": (1, 0),
         },
         "transit": {
             "aht": (0, 0),
             "pt":  (0, 0),
-            "iht": (0, 1),
+            "iht": (1, 0),
         },
         "bike": {
             "aht": (0, 0),
             "pt":  (0, 0),
-            "iht": (0, 1),
+            "iht": (1, 0),
         },
     },
     "so": {
@@ -2625,6 +2628,9 @@ distance_boundary = {
     "bike": 60,
     "walk": 15,
 }
+# O-D pairs with demand below threshold are neglected in sec dest calculation
+secondary_destination_threshold = 0.5
+
 ### DEMAND MODEL REFERENCES ###
 
 tour_purposes = (

--- a/Scripts/parameters.py
+++ b/Scripts/parameters.py
@@ -2747,7 +2747,7 @@ tour_purposes = (
         "dest": "any",
         "sec_dest": "any",
         "source": ("hw", "hc", "hu", "hs", "ho", "wo", "oo",),
-        "area": "all",
+        "area": "metropolitan",
     },
     {
         "name": "hwp",

--- a/Scripts/parameters.py
+++ b/Scripts/parameters.py
@@ -2629,7 +2629,7 @@ distance_boundary = {
     "walk": 15,
 }
 # O-D pairs with demand below threshold are neglected in sec dest calculation
-secondary_destination_threshold = 0.5
+secondary_destination_threshold = 0.1
 
 ### DEMAND MODEL REFERENCES ###
 

--- a/Scripts/tests/unit/test_logit.py
+++ b/Scripts/tests/unit/test_logit.py
@@ -17,7 +17,7 @@ class LogitModelTest(unittest.TestCase):
         pur = Purpose()
         zi = numpy.array([5, 6, 7, 2792, 16001, 17000, 31000, 31501])
         zd = ZoneData("2016_test", zi)
-        mtx = numpy.arange(24)
+        mtx = numpy.arange(24, dtype=numpy.float32)
         mtx.shape = (4, 6)
         mtx[numpy.diag_indices(4)] = 0
         impedance = {
@@ -42,24 +42,24 @@ class LogitModelTest(unittest.TestCase):
         pur.zone_numbers = (5, 6, 7, 2792)
         for i in ("hw", "hc", "hu", "hs", "ho"):
             pur.name = i
-            model = ModeDestModel(zd, pur)
+            model = ModeDestModel(zd, pur, False)
             prob = model.calc_prob(impedance)
             for mode in ("car", "transit", "bike", "walk"):
                 self._validate(prob[mode])
         for i in ("wo", "oo"):
             pur.name = i
-            model = ModeDestModel(zd, pur)
+            model = ModeDestModel(zd, pur, False)
             prob = model.calc_prob(impedance)
             for mode in ("car", "transit", "bike", "walk"):
                 self._validate(prob[mode])
         pur.name = "oop"
-        model = ModeDestModel(zd, pur)
+        model = ModeDestModel(zd, pur, False)
         prob = model.calc_prob(impedance)
         for mode in ("car", "transit"):
             self._validate(prob[mode])
         for i in ("hwp", "hop"):
             pur.name = i
-            model = ModeDestModel(zd, pur)
+            model = ModeDestModel(zd, pur, False)
             prob = model.calc_prob(impedance)
             for mode in ("car", "transit"):
                 self._validate(prob[mode])

--- a/Scripts/transform/impedance_transformer.py
+++ b/Scripts/transform/impedance_transformer.py
@@ -18,11 +18,11 @@ class ImpedanceTransformer:
             Mode (car/transit/bike/walk) : dict
                 Type (time/cost/dist) : numpy 2-d matrix
         """
+        rows = purpose.bounds
         if purpose.name == "hoo":
-            rows = slice(0, purpose.zone_data.nr_zones)
+            cols = purpose.bounds
         else:
-            rows = purpose.bounds
-        cols = slice(0, purpose.zone_data.nr_zones)
+            cols = slice(0, purpose.zone_data.nr_zones)
         day_imp = {}
         for mode in impedance_share[purpose.name]:
             day_imp[mode] = {}

--- a/Scripts/transform/impedance_transformer.py
+++ b/Scripts/transform/impedance_transformer.py
@@ -18,7 +18,10 @@ class ImpedanceTransformer:
             Mode (car/transit/bike/walk) : dict
                 Type (time/cost/dist) : numpy 2-d matrix
         """
-        rows = purpose.bounds
+        if purpose.name == "hoo":
+            rows = slice(0, purpose.zone_data.nr_zones)
+        else:
+            rows = purpose.bounds
         cols = slice(0, purpose.zone_data.nr_zones)
         day_imp = {}
         for mode in impedance_share[purpose.name]:


### PR DESCRIPTION
Calculate secondary destination only for tours within metropolitan area, and secondary destination can only be within metropolitan area. Implemented threshold for secondary destination calculation, now 0.1 o-d tours are required to calculate secondary destinations. We now have a 75% run time decrease!

Also fixed bugs in direction of impedance matrices.