### PR TITLE
Changed sources for non-home tours

### DIFF
--- a/Scripts/datatypes/person.py
+++ b/Scripts/datatypes/person.py
@@ -26,11 +26,22 @@ class Person:
 
     def add_tours(self, purposes):
         self.tours = []
-        prob = self.generation_model.calc_prob(self.age_group, self.is_car_user, self.zone)
-        pattern = numpy.random.choice(a=prob.keys(), p=prob.values())
-        tour_list = pattern.split('-')
+        prob = self.generation_model.calc_prob(
+            self.age_group, self.is_car_user, self.zone)
+        tour_combination = numpy.random.choice(a=prob.keys(), p=prob.values())
+        tour_list = tour_combination.split('-')
         if tour_list[0] == "":
             tour_list = []
         for key in tour_list:
             tour = Tour(purposes[key], self.zone)
             self.tours.append(tour)
+            if key == "hw":
+                non_home_prob = purposes["wo"].gen_model.param[key]
+                if random.random() < non_home_prob:
+                    non_home_tour = Tour(purposes["wo"], tour)
+                    self.tours.append(non_home_tour)
+            else:
+                non_home_prob = purposes["oo"].gen_model.param[key]
+                if random.random() < non_home_prob:
+                    non_home_tour = Tour(purposes["oo"], tour)
+                    self.tours.append(non_home_tour)

--- a/Scripts/datatypes/purpose.py
+++ b/Scripts/datatypes/purpose.py
@@ -70,9 +70,7 @@ class TourPurpose(Purpose):
             Data used for all demand calculations
         """
         Purpose.__init__(self, specification, zone_data)
-        if self.area == "metropolitan" and self.dest != "source":
-            self.gen_model = generation.Tours(self)
-        elif self.orig == "source":
+        if self.orig == "source":
             self.gen_model = generation.NonHomeGeneration(self)
         else:
             self.gen_model = generation.GenerationModel(self)
@@ -110,7 +108,7 @@ class TourPurpose(Purpose):
             Mode (car/transit/bike) : dict
                 Demand matrix for whole day : Demand
         """
-        tours = self.gen_model.generate_tours()
+        tours = self.gen_model.get_tours()
         demand = {}
         self.demand = {}
         self.aggregated_demand = {}
@@ -219,7 +217,7 @@ class SecDestPurpose(Purpose):
         """Generate the source tours without secondary destinations."""
         self.tours = {}
         for mode in self.model.dest_choice_param:
-            self.tours[mode] = self.gen_model.generate_tours(mode)
+            self.tours[mode] = self.gen_model.get_tours(mode)
             self.attracted_tours[mode] = self.tours[mode].sum(0)
             self.generated_tours[mode] = self.tours[mode].sum(1)
 

--- a/Scripts/datatypes/purpose.py
+++ b/Scripts/datatypes/purpose.py
@@ -128,7 +128,9 @@ class TourPurpose(Purpose):
         return demand
 
     def print_data(self):
+        attracted_tours = 0
         for mode in self.model.mode_choice_param:
+            attracted_tours += self.attracted_tours[mode]
             aggregated_demand = self._aggregate(self.demand[mode])
             result.print_matrix(aggregated_demand,
                                 "aggregated_demand", self.name + "_" + mode)
@@ -141,6 +143,9 @@ class TourPurpose(Purpose):
             result.print_data(
                 self.trip_lengths[mode], "trip_lengths.txt",
                 self.trip_lengths[mode].index, self.name + "_" + mode[0])
+        result.print_data(
+            attracted_tours, "attraction.txt",
+            self.zone_data.zone_numbers, self.name)
         demsums = self.demand_sums
         demand_all = sum(demsums.values())
         mode_shares = {mode: demsums[mode] / demand_all for mode in demsums}

--- a/Scripts/datatypes/purpose.py
+++ b/Scripts/datatypes/purpose.py
@@ -71,11 +71,11 @@ class TourPurpose(Purpose):
         """
         Purpose.__init__(self, specification, zone_data)
         if self.area == "metropolitan" and self.dest != "source":
-            self.gen_model = generation.Tours(zone_data, self)
+            self.gen_model = generation.Tours(self)
         elif self.orig == "source":
-            self.gen_model = generation.NonHomeGeneration(zone_data, self)
+            self.gen_model = generation.NonHomeGeneration(self)
         else:
-            self.gen_model = generation.GenerationModel(zone_data, self)
+            self.gen_model = generation.GenerationModel(self)
         if self.name == "sop":
             self.model = logit.OriginModel(zone_data, self)
         elif self.name == "so":
@@ -202,7 +202,7 @@ class SecDestPurpose(Purpose):
             Data used for all demand calculations
         """
         Purpose.__init__(self, specification, zone_data)
-        self.gen_model = generation.SecDestGeneration(zone_data, self)
+        self.gen_model = generation.SecDestGeneration(self)
         self.model = logit.SecDestModel(zone_data, self)
 
     def init_sums(self):

--- a/Scripts/datatypes/tour.py
+++ b/Scripts/datatypes/tour.py
@@ -34,7 +34,10 @@ class Tour:
         Position where to insert the demand
         """
         zone_data = self.purpose.zone_data
-        position = [zone_data.zone_index(self.orig)]
+        try:
+            position = [zone_data.zone_index(self.orig)]
+        except IndexError:
+            position = [zone_data.zone_index(self.orig.dest)]
         if self.dest is not None:
             position.append(zone_data.zone_index(self.dest))
         if self.sec_dest is not None:
@@ -43,7 +46,7 @@ class Tour:
 
     def choose_mode(self, is_car_user):
         model = self.purpose.model
-        probs = model.calc_individual_mode_prob(is_car_user, self.orig)
+        probs = model.calc_individual_mode_prob(is_car_user, self.position[0])
         self.mode = numpy.random.choice(a=self.purpose.modes, p=probs)
         self.purpose.generated_tours[self.mode][self.position[0]] += 1
 

--- a/Scripts/demand/trips.py
+++ b/Scripts/demand/trips.py
@@ -84,7 +84,7 @@ class DemandModel:
                     self.purpose_dict[purpose].gen_model.tours += nr_tours.values
                 nr_tours_sums[pattern] = nr_tours.sum()
             data[age] = nr_tours_sums.sort_index()
-        result.print_matrix(data, "generation", "tour_patterns")
+        result.print_matrix(data, "generation", "tour_combinations")
 
     def create_population(self):
         """Create population for agent-based simulation."""

--- a/Scripts/demand/trips.py
+++ b/Scripts/demand/trips.py
@@ -66,23 +66,30 @@ class DemandModel:
 
     def generate_tours(self):
         for purpose in self.tour_purposes:
-            purpose.gen_model.tours = 0
+            purpose.gen_model.init_tours()
+            if purpose.area == "peripheral":
+                purpose.gen_model.add_tours()
         bounds = slice(0, self.zone_data.first_peripheral_zone)
         data = pandas.DataFrame()
         for age_group in self.age_groups:
             age = "age_" + str(age_group[0]) + "-" + str(age_group[1])
+            segment = self.segments[age]
             prob_c = self.gm.calc_prob(age, is_car_user=True, zones=bounds)
             prob_n = self.gm.calc_prob(age, is_car_user=False, zones=bounds)
             nr_tours_sums = pandas.Series()
-            for pattern in prob_c:
-                nr_tours = ( prob_c[pattern] * self.segments[age]["car_users"]
-                           + prob_n[pattern] * self.segments[age]["no_car"])
-                tour_list = pattern.split('-')
+            for combination in prob_c:
+                nr_tours = ( prob_c[combination] * segment["car_users"]
+                           + prob_n[combination] * segment["no_car"])
+                tour_list = combination.split('-')
                 if tour_list[0] == "":
                     tour_list = []
                 for purpose in tour_list:
-                    self.purpose_dict[purpose].gen_model.tours += nr_tours.values
-                nr_tours_sums[pattern] = nr_tours.sum()
+                    self.purpose_dict[purpose].gen_model.tours += nr_tours
+                nr_tours_sums[combination] = nr_tours.sum()
+            for purpose in self.tour_purposes:
+                if purpose.dest == "source" and purpose.area == "metropolitan":
+                    purpose.gen_model.add_tours(segment["car_users"], age, "car_users")
+                    purpose.gen_model.add_tours(segment["no_car"], age, "no_car")
             data[age] = nr_tours_sums.sort_index()
         result.print_matrix(data, "generation", "tour_combinations")
 

--- a/Scripts/demand/trips.py
+++ b/Scripts/demand/trips.py
@@ -67,7 +67,7 @@ class DemandModel:
     def generate_tours(self):
         for purpose in self.tour_purposes:
             purpose.gen_model.init_tours()
-            if purpose.area == "peripheral":
+            if purpose.area == "peripheral" or purpose.dest == "source":
                 purpose.gen_model.add_tours()
         bounds = slice(0, self.zone_data.first_peripheral_zone)
         data = pandas.DataFrame()
@@ -86,10 +86,6 @@ class DemandModel:
                 for purpose in tour_list:
                     self.purpose_dict[purpose].gen_model.tours += nr_tours
                 nr_tours_sums[combination] = nr_tours.sum()
-            for purpose in self.tour_purposes:
-                if purpose.dest == "source" and purpose.area == "metropolitan":
-                    purpose.gen_model.add_tours(segment["car_users"], age, "car_users")
-                    purpose.gen_model.add_tours(segment["no_car"], age, "no_car")
             data[age] = nr_tours_sums.sort_index()
         result.print_matrix(data, "generation", "tour_combinations")
 

--- a/Scripts/models/generation.py
+++ b/Scripts/models/generation.py
@@ -10,8 +10,30 @@ class GenerationModel:
         self.purpose = purpose
         self.param = parameters.tour_generation[purpose.name]
 
-    def generate_tours(self):
-        """Generate vector of tour numbers
+    def init_tours(self):
+        self.tours = pandas.Series(0, self.purpose.zone_numbers)
+
+    def add_tours(self, segment=None, age=None, is_car_user=None):
+        """Add generated tours to vector.
+        
+        Parameters
+        ----------
+        segment : numpy 1-d array, optional
+            Population segment for which tours are added
+        age : string, optional
+            Age group of population segment
+        is_car_user : string, optional
+            Whether population segment consists of car users or not
+        """
+        b = self.param
+        for i in b:
+            try:
+                self.tours += b[i] * self.zone_data[i][self.purpose.bounds]
+            except TypeError:
+                self.tours += b[i][age][is_car_user] * segment
+
+    def get_tours(self):
+        """Get vector of tour numbers
         from zone data.
         
         Return
@@ -19,30 +41,16 @@ class GenerationModel:
         numpy 1-d array
             Vector of tour numbers per zone
         """
-        tours = 0
-        b = self.param
-        for i in b:
-            tours += b[i] * self.zone_data[i][self.purpose.bounds]
         result.print_data(
-            tours, "tours.txt", self.zone_data.zone_numbers, self.purpose.name)
-        return tours.values
-
-
-class Tours(GenerationModel):
-    def __init__(self, purpose):
-        self.zone_data = purpose.zone_data
-        self.purpose = purpose
-        self.tours = 0
-    
-    def generate_tours(self):
-        result.print_data(
-            pandas.Series(self.tours, self.purpose.zone_numbers),
-            "tours.txt", self.zone_data.zone_numbers, self.purpose.name)
-        return self.tours
+            self.tours, "tours.txt", self.zone_data.zone_numbers, self.purpose.name)
+        return self.tours.values
 
 
 class NonHomeGeneration(GenerationModel):
-    def generate_tours(self):
+    def add_tours(self, segment, age, is_car_user):
+        pass
+    
+    def get_tours(self):
         """Generate vector of tour numbers
         from attracted source tours.
         
@@ -63,7 +71,7 @@ class NonHomeGeneration(GenerationModel):
 
 
 class SecDestGeneration(GenerationModel):
-    def generate_tours(self, mode):
+    def get_tours(self, mode):
         """Generate matrix of tour numbers
         from attracted source tours.
         

--- a/Scripts/models/generation.py
+++ b/Scripts/models/generation.py
@@ -26,11 +26,11 @@ class GenerationModel:
             Whether population segment consists of car users or not
         """
         b = self.param
-        for i in b:
-            try:
+        try:
+            for i in b:
                 self.tours += b[i] * self.zone_data[i][self.purpose.bounds]
-            except TypeError:
-                self.tours += b[i][age][is_car_user] * segment
+        except KeyError:
+            self.tours += b[age][is_car_user] * segment
 
     def get_tours(self):
         """Get vector of tour numbers

--- a/Scripts/models/generation.py
+++ b/Scripts/models/generation.py
@@ -1,9 +1,12 @@
 import numpy
+import pandas
 import parameters
+import datahandling.resultdata as result
+
 
 class GenerationModel:
-    def __init__(self, zone_data, purpose):
-        self.zone_data = zone_data
+    def __init__(self, purpose):
+        self.zone_data = purpose.zone_data
         self.purpose = purpose
         self.param = parameters.tour_generation[purpose.name]
 
@@ -20,16 +23,21 @@ class GenerationModel:
         b = self.param
         for i in b:
             tours += b[i] * self.zone_data[i][self.purpose.bounds]
+        result.print_data(
+            tours, "tours.txt", self.zone_data.zone_numbers, self.purpose.name)
         return tours.values
 
 
 class Tours(GenerationModel):
-    def __init__(self, zone_data, purpose):
-        self.zone_data = zone_data
+    def __init__(self, purpose):
+        self.zone_data = purpose.zone_data
         self.purpose = purpose
         self.tours = 0
     
     def generate_tours(self):
+        result.print_data(
+            pandas.Series(self.tours, self.purpose.zone_numbers),
+            "tours.txt", self.zone_data.zone_numbers, self.purpose.name)
         return self.tours
 
 
@@ -48,6 +56,9 @@ class NonHomeGeneration(GenerationModel):
             b = self.param[source.name]
             for mode in source.attracted_tours:
                 tours += b * source.attracted_tours[mode]
+        result.print_data(
+            pandas.Series(tours, self.purpose.zone_numbers),
+            "tours.txt", self.zone_data.zone_numbers, self.purpose.name)
         return tours
 
 

--- a/Scripts/models/generation.py
+++ b/Scripts/models/generation.py
@@ -13,7 +13,7 @@ class GenerationModel:
     def init_tours(self):
         self.tours = pandas.Series(0, self.purpose.zone_numbers)
 
-    def add_tours(self, segment=None, age=None, is_car_user=None):
+    def add_tours(self):
         """Add generated tours to vector.
         
         Parameters
@@ -26,11 +26,8 @@ class GenerationModel:
             Whether population segment consists of car users or not
         """
         b = self.param
-        try:
-            for i in b:
-                self.tours += b[i] * self.zone_data[i][self.purpose.bounds]
-        except KeyError:
-            self.tours += b[age][is_car_user] * segment
+        for i in b:
+            self.tours += b[i] * self.zone_data[i][self.purpose.bounds]
 
     def get_tours(self):
         """Get vector of tour numbers
@@ -47,7 +44,7 @@ class GenerationModel:
 
 
 class NonHomeGeneration(GenerationModel):
-    def add_tours(self, segment, age, is_car_user):
+    def add_tours(self):
         pass
     
     def get_tours(self):

--- a/Scripts/models/logit.py
+++ b/Scripts/models/logit.py
@@ -228,24 +228,23 @@ class ModeDestModel(LogitModel):
         is_car_user : bool
             Whether the agent is car user or not
         zone : int
-            Zone number where the agent lives
+            Index of zone where the agent lives
         
         Return
         ------
         list
             Choice probabilities for purpose modes
         """
-        zone_idx = self.zone_data.zone_index(zone)
         mode_exps = {}
         mode_expsum = 0
         for mode in self.mode_choice_param:
-            mode_exps[mode] = self.mode_exps[mode][zone_idx]
+            mode_exps[mode] = self.mode_exps[mode][zone]
             b = self.mode_choice_param[mode]["individual_dummy"]
             if is_car_user and "car_users" in b:
                 try:
                     mode_exps[mode] *= math.exp(b["car_users"])
                 except TypeError:
-                    if zone_idx < self.zone_data.first_surrounding_zone:
+                    if zone < self.zone_data.first_surrounding_zone:
                         mode_exps[mode] *= math.exp(b["car_users"][0])
                     else:
                         mode_exps[mode] *= math.exp(b["car_users"][1])

--- a/Scripts/models/logit.py
+++ b/Scripts/models/logit.py
@@ -359,11 +359,11 @@ class OriginModel(LogitModel):
         size = numpy.ones_like(exps)
         size = self._add_zone_util(size, b["size"])
         exps *= numpy.power(size, b["log"]["size"])
-        expsums = numpy.sum(exps, axis=0)
+        expsums = numpy.sum(exps, axis=1)
         prob = {}
         # Mode is needed here to get through tests even
         # though the origin model does not take modes into account.
-        prob["all"] = (exps / expsums).T
+        prob["all"] = exps.T / expsums
         return prob
 
 

--- a/Scripts/modelsystem.py
+++ b/Scripts/modelsystem.py
@@ -75,9 +75,7 @@ class ModelSystem:
                     if purpose.area == "peripheral" or purpose.orig == "source" or purpose.dest == "source":
                         purpose.calc_prob(purpose_impedance)
                         purpose.gen_model.init_tours()
-                        if purpose.area == "peripheral":
-                            purpose.gen_model.add_tours()
-                        # TODO Add non-home tours
+                        purpose.gen_model.add_tours()
                         demand = purpose.calc_demand()
                         if purpose.dest != "source":
                             for mode in demand:

--- a/Scripts/modelsystem.py
+++ b/Scripts/modelsystem.py
@@ -72,7 +72,7 @@ class ModelSystem:
                     purpose.init_sums()
                 else:
                     purpose_impedance = self.imptrans.transform(purpose, impedance)
-                    if purpose.area == "peripheral" or purpose.orig == "source" or purpose.dest == "source":
+                    if purpose.area == "peripheral" or purpose.name == "oop":
                         purpose.calc_prob(purpose_impedance)
                         purpose.gen_model.init_tours()
                         purpose.gen_model.add_tours()

--- a/Scripts/modelsystem.py
+++ b/Scripts/modelsystem.py
@@ -74,6 +74,10 @@ class ModelSystem:
                     purpose_impedance = self.imptrans.transform(purpose, impedance)
                     if purpose.area == "peripheral" or purpose.orig == "source" or purpose.dest == "source":
                         purpose.calc_prob(purpose_impedance)
+                        purpose.gen_model.init_tours()
+                        if purpose.area == "peripheral":
+                            purpose.gen_model.add_tours()
+                        # TODO Add non-home tours
                         demand = purpose.calc_demand()
                         if purpose.dest != "source":
                             for mode in demand:

--- a/Scripts/parameters.py
+++ b/Scripts/parameters.py
@@ -2614,12 +2614,13 @@ tour_generation = {
         "population": 0.133325428,
     },
     "wo": {
-        # Some so trips continue with wo trips
-        "so": 0.065687335 / 0.133325428,
+        "hw": 0.154948467,
     },
     "oo": {
-        # Some so trips continue with oo trips
-        "so": 0.067638093 / 0.133325428,
+        "hc": 0.056962844,
+        "hu": 0.1024485,
+        "hs": 0.114918825,
+        "ho": 0.030784426,
     },
     "hwp": {
         "population": 0.237579403,
@@ -2737,14 +2738,14 @@ tour_purposes = (
         "name": "wo",
         "orig": "source",
         "dest": "other",
-        "source": ("so",),
+        "source": ("hw",),
         "area": "all",
     },
     {
         "name": "oo",
         "orig": "source",
         "dest": "other",
-        "source": ("so",),
+        "source": ("hc", "hu", "hs", "ho",),
         "area": "all",
     },
     {

--- a/Scripts/parameters.py
+++ b/Scripts/parameters.py
@@ -1286,23 +1286,6 @@ destination_choice = {
             },
         },
     },
-    "so": {
-        "logsum": {
-            "attraction": {
-                "own_zone": 0.578607605,
-            },
-            "impedance": {},
-            "log": {
-                "logsum": 1.011586109,
-                "size": 0.814168308,
-            },
-            "size": {
-                "population": 1,
-                "workplaces": 2.572258993,
-                "cbd": (1, 5.674738917), # Fix
-            },
-        },
-    },
     "wo": {
         "car": {
             "attraction": {
@@ -1836,56 +1819,6 @@ mode_choice = {
         },
     },
     "hoo": None,
-    "so": {
-        "car": {
-            "constant": 0,
-            "generation": {},
-            "attraction": {
-                "parking_cost_work": -0.35058138,
-            },
-            "impedance": {
-                "time": -0.021901628,
-                "cost": -0.10378753,
-            },
-            "log": {},
-            "individual_dummy": {},
-        },
-        "transit": {
-            "constant": 0.437744247,
-            "generation": {},
-            "attraction": {
-                "cbd": 0.502605142,
-            },
-            "impedance": {
-                "time": -0.015704891,
-                "cost": -0.10378753 / 30,
-            },
-            "log": {},
-            "individual_dummy": {},
-        },
-        "bike": {
-            "constant": 0.911203717,
-            "generation": {},
-            "attraction": {},
-            "impedance": {},
-            "log": {
-                "dist": -1.292779721,
-            },
-            "individual_dummy": {},
-        }, 
-        "walk": {
-            "constant": 3.309720696,
-            "generation": {},
-            "attraction": {
-                "own_zone_area_sqrt": -2.154849688,
-            },
-            "impedance": {},
-            "log": {
-                "dist": -2.70272318,
-            },
-            "individual_dummy": {},
-        },
-    },
     "wo": {
        "car": {
             "constant": 0,
@@ -2610,9 +2543,6 @@ tour_generation = {
         "wo": 0.006012753 / 0.065687335,
         "oo": 0.007727243 / 0.067638093,
     },
-    "so": {
-        "population": 0.133325428,
-    },
     "wo": {
         "hw": 0.154948467,
     },
@@ -2726,12 +2656,6 @@ tour_purposes = (
         "name": "ho",
         "orig": "home",
         "dest": "other",
-        "area": "metropolitan",
-    },
-    {
-        "name": "so",
-        "orig": "home",
-        "dest": "source",
         "area": "metropolitan",
     },
     {

--- a/Scripts/parameters.py
+++ b/Scripts/parameters.py
@@ -2611,7 +2611,26 @@ tour_generation = {
         "oo": 0.007727243 / 0.067638093,
     },
     "so": {
-        "population": 0.133325428,
+        "age_7-17": {
+            "car_users": 0,
+            "no_car": 0.099337,
+        },
+        "age_18-29": {
+            "car_users": 0.079434,
+            "no_car": 0.074901,
+        },
+        "age_30-49": {
+            "car_users": 0.051977,
+            "no_car": 0.038302,
+        },
+        "age_50-64": {
+            "car_users": 0.060209,
+            "no_car": 0.039072,
+        },
+        "age_65-99": {
+            "car_users": 0.072075,
+            "no_car": 0.077359,
+        },
     },
     "wo": {
         # Some so trips continue with wo trips
@@ -2619,7 +2638,7 @@ tour_generation = {
     },
     "oo": {
         # Some so trips continue with oo trips
-        "so": 0.067638093 / 0.133325428,
+        "so": 1,
     },
     "hwp": {
         "population": 0.237579403,

--- a/Scripts/parameters.py
+++ b/Scripts/parameters.py
@@ -2611,26 +2611,7 @@ tour_generation = {
         "oo": 0.007727243 / 0.067638093,
     },
     "so": {
-        "age_7-17": {
-            "car_users": 0,
-            "no_car": 0.099337,
-        },
-        "age_18-29": {
-            "car_users": 0.079434,
-            "no_car": 0.074901,
-        },
-        "age_30-49": {
-            "car_users": 0.051977,
-            "no_car": 0.038302,
-        },
-        "age_50-64": {
-            "car_users": 0.060209,
-            "no_car": 0.039072,
-        },
-        "age_65-99": {
-            "car_users": 0.072075,
-            "no_car": 0.077359,
-        },
+        "population": 0.133325428,
     },
     "wo": {
         # Some so trips continue with wo trips
@@ -2638,7 +2619,7 @@ tour_generation = {
     },
     "oo": {
         # Some so trips continue with oo trips
-        "so": 1,
+        "so": 0.067638093 / 0.133325428,
     },
     "hwp": {
         "population": 0.237579403,

--- a/Scripts/tests/unit/test_logit.py
+++ b/Scripts/tests/unit/test_logit.py
@@ -46,11 +46,6 @@ class LogitModelTest(unittest.TestCase):
             prob = model.calc_prob(impedance)
             for mode in ("car", "transit", "bike", "walk"):
                 self._validate(prob[mode])
-        pur.name = "so"
-        model = DestModeModel(zd, pur)
-        prob = model.calc_prob(impedance)
-        for mode in ("car", "transit", "bike", "walk"):
-            self._validate(prob[mode])
         for i in ("wo", "oo"):
             pur.name = i
             model = ModeDestModel(zd, pur)


### PR DESCRIPTION
Now normal home-based tours are sources for non-home tours. Virtual tour purpose so is removed. For peripheral non-home tours, virtual purpose sop is still source, as the number of total tours is a bit unclear at the moment.

Also prints number of generated and attracted tours per zone.