### PR TITLE
Fix/sop

### DIFF
--- a/Scripts/models/logit.py
+++ b/Scripts/models/logit.py
@@ -74,14 +74,6 @@ class LogitModel:
             dest_exps[impedance["dist"] > threshold] = 0
         return dest_exps
 
-    def _calc_origin_util(self, impedance):
-        b = self.dest_choice_param
-        utility = numpy.zeros_like(next(iter(impedance["car"].values())))
-        for mode in b["impedance"]:
-            self._add_impedance(utility, impedance[mode], b["impedance"][mode])
-        self._add_zone_util(utility, b["attraction"])
-        return utility
-
     def _add_constant(self, utility, b):
         try: # If only one parameter
             utility += b
@@ -385,6 +377,14 @@ class OriginModel(LogitModel):
         # though the origin model does not take modes into account.
         prob["all"] = exps.T / expsums
         return prob
+
+    def _calc_origin_util(self, impedance):
+        b = self.dest_choice_param
+        utility = numpy.zeros_like(next(iter(impedance["car"].values())))
+        for mode in b["impedance"]:
+            self._add_impedance(utility, impedance[mode], b["impedance"][mode])
+        self._add_zone_util(utility, b["attraction"])
+        return utility
 
 
 class GenerationModel():

--- a/Scripts/parameters.py
+++ b/Scripts/parameters.py
@@ -1608,27 +1608,41 @@ destination_choice = {
     },
     "sop": {
         "attraction": {
-            "parking_cost_errand": 0.94 * -0.609e-1,
-            "population_density": -0.109e-3,
+            "own_zone": 0.451052614,
         },
-        "impedance": {
-            "car": {
-                "cost": 0.94 * -0.609e-1,
-                "time": 0.94 * -0.264e-1,
-            },
-            "transit": {
-                "cost": 0.04 * (-0.609e-1) / 30,
-                "time": 0.04 * -0.264e-1,
-            },
-        },
+        "impedance": {},
         "log": {
             "size": 0.823988178,
+            "exp": 0.852045667,
         },
         "size": {
             "workplaces": numpy.exp(3.941389653),
             "population_own": numpy.exp(3.054259386),
             "population_other": 1.0,
         },
+        "utility": {
+            "car": {
+                "constant": 0,
+                "generation": {},
+                "attraction": {
+                    "own_zone_area": -0.01478815,
+                    "parking_cost_work": -0.154340268,
+                },
+                "impedance": {
+                    "time": -0.021262374,
+                    "cost": -0.154340268,
+                },
+            },
+            "transit": {
+                "constant": -2.060141017,
+                "generation": {},
+                "attraction": {},
+                "impedance": {
+                    "time": -0.007909217,
+                    "cost": -0.154340268 / 30,
+                },
+            }
+        }
     },
     "oop": {
         "car": {
@@ -2030,8 +2044,7 @@ mode_choice = {
         },
     },
     "sop": {
-        "all": {
-        },
+        "all": {},
     },
     "oop": {
         "car": {

--- a/Scripts/parameters.py
+++ b/Scripts/parameters.py
@@ -1622,12 +1622,12 @@ destination_choice = {
             },
         },
         "log": {
-            "size": 1,
+            "size": 0.823988178,
         },
         "size": {
-            "workplaces": numpy.exp(2.53759200723),
-            "population_own": numpy.exp(1.17058855327),
-            "population_other": 1,
+            "workplaces": numpy.exp(3.941389653),
+            "population_own": numpy.exp(3.054259386),
+            "population_other": 1.0,
         },
     },
     "oop": {
@@ -2031,7 +2031,6 @@ mode_choice = {
     },
     "sop": {
         "all": {
-            "individual_dummy": {},
         },
     },
     "oop": {

--- a/Scripts/parameters.py
+++ b/Scripts/parameters.py
@@ -1607,22 +1607,22 @@ destination_choice = {
         },
     },
     "sop": {
+        "constant": 0.0,
         "attraction": {
             "own_zone": 0.451052614,
         },
-        "impedance": {},
         "log": {
             "size": 0.823988178,
-            "exp": 0.852045667,
+            "exponent": 0.852045667,
         },
         "size": {
             "workplaces": numpy.exp(3.941389653),
             "population_own": numpy.exp(3.054259386),
             "population_other": 1.0,
         },
-        "utility": {
+        "exponent": {
             "car": {
-                "constant": 0,
+                "constant": 0.0,
                 "generation": {},
                 "attraction": {
                     "own_zone_area": -0.01478815,


### PR DESCRIPTION
This PR fixes the calculation of probabilities in OriginModel ("sop"). Parameters have been updated. Parameter values where found and organized by @TimoElolahde, thanks! The new script handles mode-dependent exponent terms (`exponent` in `parameters.py`) in a new method, `_add_exponent_terms`.

Changes to `OriginModel` code have been quite large, especially regarding exponent terms, so I am waiting for @zptro's review before merging to master.