### PR TITLE
Feat/sop2

### DIFF
--- a/Scripts/models/logit.py
+++ b/Scripts/models/logit.py
@@ -356,33 +356,7 @@ class SecDestModel(LogitModel):
 
 
 class OriginModel(DestModeModel):
-    def calc_prob(self, impedance):
-        """Calculate matrix of choice probabilities.
-        
-        Parameters
-        ----------
-        impedance : dict
-            Mode (car/transit/bike/walk) : dict
-                Type (time/cost/dist) : numpy 2-d matrix
-                    Impedances
-        
-        Return
-        ------
-        dict
-            Mode (car/transit/bike/walk) : numpy 2-d matrix
-                Choice probabilities
-        """
-        # Sum of exponents in V(d)
-        mode_expsum = self._calc_mode_util(impedance)
-        logsum = {"logsum": mode_expsum}
-        # U = V(d) + LSM*ln(S(d)) = dest_expsum["logsum"]
-        dest_expsum = self._calc_dest_util("logsum", logsum)
-        prob = {}
-        dest_prob = self.dest_exps["logsum"].T / dest_expsum
-        for mode in self.mode_choice_param:
-            mode_prob = (self.mode_exps[mode] / mode_expsum).T
-            prob[mode] = mode_prob * dest_prob
-        return prob
+    pass
 
 
 class GenerationModel():

--- a/Scripts/models/logit.py
+++ b/Scripts/models/logit.py
@@ -377,12 +377,12 @@ class OriginModel(DestModeModel):
         logsum = {"logsum": mode_expsum}
         # U = V(d) + LSM*ln(S(d)) = dest_expsum["logsum"]
         dest_expsum = self._calc_dest_util("logsum", logsum)
-        # prob = {}
+        prob = {}
         dest_prob = self.dest_exps["logsum"].T / dest_expsum
-        # for mode in self.mode_choice_param:
-        #     mode_prob = (self.mode_exps[mode] / mode_expsum).T
-        #     prob[mode] = mode_prob * dest_prob
-        return dest_prob
+        for mode in self.mode_choice_param:
+            mode_prob = (self.mode_exps[mode] / mode_expsum).T
+            prob[mode] = mode_prob * dest_prob
+        return prob
 
 
 class GenerationModel():

--- a/Scripts/parameters.py
+++ b/Scripts/parameters.py
@@ -2027,7 +2027,7 @@ mode_choice = {
             "constant": 0.0,
             "generation": {},
             "attraction": {
-				"own_zone_area": -0.01478815,
+                "own_zone_area": -0.01478815,
                 "parking_cost_work": -0.154340268,
             },
             "impedance": {

--- a/Scripts/parameters.py
+++ b/Scripts/parameters.py
@@ -1607,27 +1607,20 @@ destination_choice = {
         },
     },
     "sop": {
-        "attraction": {
-            "parking_cost_errand": 0.94 * -0.609e-1,
-            "population_density": -0.109e-3,
-        },
-        "impedance": {
-            "car": {
-                "cost": 0.94 * -0.609e-1,
-                "time": 0.94 * -0.264e-1,
+        "logsum": {
+            "attraction": {
+                "own_zone": 0.451052614,
             },
-            "transit": {
-                "cost": 0.04 * (-0.609e-1) / 30,
-                "time": 0.04 * -0.264e-1,
+            "impedance": {},
+            "log": {
+                "logsum": 0.852045667,
+                "size": 0.823988178,
             },
-        },
-        "log": {
-            "size": 1,
-        },
-        "size": {
-            "workplaces": numpy.exp(2.53759200723),
-            "population_own": numpy.exp(1.17058855327),
-            "population_other": 1,
+            "size": {
+                "workplaces": numpy.exp(3.941389653),
+                "population_own": numpy.exp(3.054259386),
+                "population_other": 1.0,
+            },
         },
     },
     "oop": {
@@ -2030,7 +2023,29 @@ mode_choice = {
         },
     },
     "sop": {
-        "all": {
+        "car": {
+            "constant": 0.0,
+            "generation": {},
+            "attraction": {
+				"own_zone_area": -0.01478815,
+                "parking_cost_work": -0.154340268,
+            },
+            "impedance": {
+                "time": -0.021262374,
+                "cost": -0.154340268,
+            },
+            "log": {},
+            "individual_dummy": {},
+        },
+        "transit": {
+            "constant": -2.060141017,
+            "generation": {},
+            "attraction": {},
+            "impedance": {
+                "time": -0.007909217,
+                "cost": -0.154340268 / 30,
+            },
+            "log": {},
             "individual_dummy": {},
         },
     },


### PR DESCRIPTION
This is a new version of the `sop` model which chooses the origin zone for non-home-based tours of the people living in peripheral municipalities. This replaces and closes #123 with another solution.

Otherwise this works, but some help is needed:

- This PR introduces modes car and transit to sop model. Previously, the probability dictionary was a dictionary with only one mode, `all`. Does this affect the origin choice?
- If the modes are now "real" modes, does this affect the assignment? Virtual tours generated in `sop` model should not be assigned.
