### PR TITLE
Rename logit model based GenerationModel to TourCombinationModel

### DIFF
--- a/Scripts/demand/trips.py
+++ b/Scripts/demand/trips.py
@@ -37,7 +37,7 @@ class DemandModel:
                         self.purpose_dict[source].sec_dest_purpose = purpose
         bounds = slice(0, zone_data.first_peripheral_zone)
         self.cm = logit.CarUseModel(zone_data, bounds)
-        self.gm = logit.GenerationModel(self.zone_data)
+        self.gm = logit.TourCombinationModel(self.zone_data)
         zone_data["car_users"] = self.cm.calc_prob()
         self.age_groups = (
             (7, 17),

--- a/Scripts/models/logit.py
+++ b/Scripts/models/logit.py
@@ -387,7 +387,7 @@ class OriginModel(LogitModel):
         return prob
 
 
-class GenerationModel():
+class TourCombinationModel():
     def __init__(self, zone_data):
         self.zone_data = zone_data
         self.param = parameters.tour_combinations

--- a/Scripts/tests/unit/test_tourcombination.py
+++ b/Scripts/tests/unit/test_tourcombination.py
@@ -6,17 +6,17 @@ import pandas
 import unittest
 import parameters
 from datahandling.zonedata import ZoneData
-from models.logit import GenerationModel
+from models.logit import TourCombinationModel
 import datahandling.resultdata as result
 
 
-class GenerationModelTest(unittest.TestCase):
+class TourCombinationModelTest(unittest.TestCase):
     def test_generation(self):
         zi = numpy.array([5, 6, 7, 2792, 16001, 17000, 31000, 31501])
         zd = ZoneData("2016_test", zi)
         zd._values["hu_t"] = pandas.Series([0, 0, 0, 0], [5, 6, 7, 2792])
         zd._values["ho_w"] = pandas.Series([0, 0, 0, 0], [5, 6, 7, 2792])
-        model = GenerationModel(zd)
+        model = TourCombinationModel(zd)
         prob = model.calc_prob("age_50-64", False, 6)
         self.assertIs(type(prob["hw"]), numpy.float64)
         self.assertAlmostEquals(sum(prob.values()), 1)


### PR DESCRIPTION
There already is another GenerationModel that generates a correct number of
tours per people. This model generates a proper combination of different types
of tours.

Closes #126