### PR TITLE
Assignment class fix

### DIFF
--- a/Scripts/assignment/abstract_assignment.py
+++ b/Scripts/assignment/abstract_assignment.py
@@ -43,7 +43,7 @@ class ImpedanceSource:
         pass
 
     @abstractmethod
-    def get_matrices(self, mtx_type, time_period=None):
+    def get_emmebank_matrices(self, mtx_type, time_period=None):
         pass
 
     @abstractmethod

--- a/Scripts/assignment/mock_assignment.py
+++ b/Scripts/assignment/mock_assignment.py
@@ -36,11 +36,11 @@ class MockAssignmentModel(AssignmentModel, ImpedanceSource):
             Type (time/cost/dist) : dict
                 Assignment class (car_work/transit/...) : numpy 2-d matrix
         """
-        return {"time": self.get_matrices("time", self.time_period),
-                "cost": self.get_matrices("cost", self.time_period),
-                "dist": self.get_matrices("dist", self.time_period)}
+        return {"time": self.get_emmebank_matrices("time", self.time_period),
+                "cost": self.get_emmebank_matrices("cost", self.time_period),
+                "dist": self.get_emmebank_matrices("dist", self.time_period)}
     
-    def get_matrices(self, mtx_type, time_period=None):
+    def get_emmebank_matrices(self, mtx_type, time_period=None):
         """Get all matrices of specified type.
         
         Parameters

--- a/Scripts/datahandling/matrixdata.py
+++ b/Scripts/datahandling/matrixdata.py
@@ -18,6 +18,13 @@ class MatrixData:
         yield mtxfile
         mtxfile.close()
 
+    def list_matrices(self, mtx_type, time_period, m='r'):
+        file_name = os.path.join(self.path, mtx_type+'_'+time_period+".omx")
+        mtxfile = omx.open_file(file_name, m)
+        names = mtxfile.list_matrices()
+        mtxfile.close()
+        return names
+
     def get_external(self, transport_mode):
         return read_csv_file(self.path, "external_"+transport_mode+".txt")
 

--- a/Scripts/modelsystem.py
+++ b/Scripts/modelsystem.py
@@ -37,7 +37,10 @@ class ModelSystem:
                                 self.ass_model.zone_numbers)
         self.dtm = dt.DepartureTimeModel(self.ass_model.nr_zones)
         self.imptrans = ImpedanceTransformer()
-        self.ass_classes = dict.fromkeys(parameters.emme_mtx["demand"].keys())
+        # TODO: Should be better defined as parameter when we don't  
+        # have different transit matrices as input data. 
+        # Could use this list_matrices as inpout validation.
+        self.ass_classes = self.basematrices.list_matrices("demand", "aht")
         self.mode_share = []
         self.trucks = self.fm.calc_freight_traffic("truck")
         self.trailer_trucks = self.fm.calc_freight_traffic("trailer_truck")


### PR DESCRIPTION
Modifications to allow test runs with different full model system specs:
* Method name in abstract assignment and mock assignment same as in emme assignment. This would give error otherwise. 
* Get modelsystem assignment classes from mtx files to allow test runs both with "transit" and "transit_leisure" / "transit_work".