### PR TITLE
Fix vehicle_kms calculation

### DIFF
--- a/Scripts/assignment/emme_assignment.py
+++ b/Scripts/assignment/emme_assignment.py
@@ -305,6 +305,7 @@ class EmmeAssignmentModel(AssignmentModel, ImpedanceSource):
                         car_vol -= link[param.link_volumes[ass_class]]
                     kms["car"][vdf] += (param.volume_factors["car"][tp] * car_vol * link.length)
             for line in network.transit_lines():
+                mode = "other"
                 for modes in transit_modes:
                     if line.mode.id in transit_modes[modes]:
                         mode = modes


### PR DESCRIPTION
A for loop in print_vehicle_kms() can skip initializing 'mode' variable and report the statistics for a wrong vehicle type.