### PR TITLE
Distance cost from Zonedata

### DIFF
--- a/Scripts/assignment/emme_assignment.py
+++ b/Scripts/assignment/emme_assignment.py
@@ -9,8 +9,7 @@ from datatypes.path_analysis import PathAnalysis
 
 
 class EmmeAssignmentModel(AssignmentModel, ImpedanceSource):
-    def __init__(self, emme_context, first_scenario_id, car_dist_cost=param.dist_unit_cost,
-                demand_mtx=param.emme_demand_mtx, result_mtx=param.emme_result_mtx):
+    def __init__(self, emme_context, first_scenario_id, demand_mtx=param.emme_demand_mtx, result_mtx=param.emme_result_mtx):
         """
         first_scenario_id (bike scenario) is usually #19,
             followed by (#20) walk scenario, (#21) morning scenario, (#22) midday scenario, and (#23) evening scenario.
@@ -36,23 +35,26 @@ class EmmeAssignmentModel(AssignmentModel, ImpedanceSource):
                     matrix_description=mtx[ass_class]["description"],
                     default_value=999999,
                     overwrite=True)
-        self.dist_unit_cost = car_dist_cost
+        # default value for dist. Modelsystem sets new from zonedata
+        self.dist_unit_cost = param.dist_unit_cost
         self.bike_scenario = first_scenario_id
-        self.create_attributes(self.bike_scenario, param.bike_attributes)
         self.day_scenario = first_scenario_id+1
-        self.create_attributes(self.day_scenario, param.emme_attributes)
         self.emme_scenarios = {
             "aht": first_scenario_id+2,
             "pt": first_scenario_id+3,
             "iht": first_scenario_id+4,
         }
+
+    def _prepare_network(self):
+        """Create extra attributes and calc backgroud variables for assignment."""
+        self.create_attributes(self.bike_scenario, param.bike_attributes)
+        self.create_attributes(self.day_scenario, param.emme_attributes)
         for time_period in self.emme_scenarios:
             self.create_attributes(self.emme_scenarios[time_period], param.emme_attributes)
             self._calc_road_cost(self.emme_scenarios[time_period])
             self._calc_boarding_penalties(self.emme_scenarios[time_period])
             self._calc_background_traffic(self.emme_scenarios[time_period])
         self._specify()
-        self._has_assigned_bike_and_walk = False
 
     def assign(self, time_period, matrices, is_last_iteration=False, is_first_iteration=False):
         """Assign cars, bikes and transit for one time period.
@@ -69,14 +71,17 @@ class EmmeAssignmentModel(AssignmentModel, ImpedanceSource):
         self.emme_project.logger.info("Assignment starts...")
         self.set_emmebank_matrices(matrices)
         scen_id = self.emme_scenarios[time_period]
-        if not self._has_assigned_bike_and_walk:
+        if is_first_iteration:
+            self._prepare_network()
             self._assign_pedestrians(scen_id)
             self._assign_bikes(self.bike_scenario,
                             self.result_mtx["dist"]["bike"]["id"],
                             "all",
                             "@bike_"+time_period)
-            self._has_assigned_bike_and_walk = True
-        if is_last_iteration:
+            self._assign_cars(scen_id, param.stopping_criteria_coarse)
+            self._calc_extra_wait_time(scen_id)
+            self._assign_transit(scen_id)
+        elif is_last_iteration:
             self._assign_cars(scen_id, param.stopping_criteria_fine)
             self._calc_extra_wait_time(scen_id)
             self._assign_congested_transit(scen_id)

--- a/Scripts/datahandling/zonedata.py
+++ b/Scripts/datahandling/zonedata.py
@@ -38,8 +38,8 @@ class ZoneData:
         transit_zone["dist_fare"] = transit_zone["fare"].pop("dist")
         transit_zone["start_fare"] = transit_zone["fare"].pop("start")
         self.transit_zone = transit_zone
-        car_cost = read_csv_file(data_dir, ".cco", squeeze=True)
-        self.car_dist_cost = car_cost[0]
+        car_cost = read_csv_file(data_dir, ".cco", squeeze=False)
+        self.car_dist_cost = car_cost["dist_cost"][0]
         truckdata = read_csv_file(data_dir, ".trk", squeeze=True)
         self.trailers_prohibited = map(int, truckdata.loc[0, :])
         self.garbage_destination = map(int, truckdata.loc[1, :].dropna())

--- a/Scripts/modelsystem.py
+++ b/Scripts/modelsystem.py
@@ -22,7 +22,9 @@ class ModelSystem:
         # Input data
         self.zdata_base = ZoneData(base_zone_data_path, ass_model.zone_numbers)
         self.basematrices = MatrixData(base_matrices_path)
-        self.zdata_forecast = ZoneData(zone_data_path, ass_model.zone_numbers)
+        self.zdata_forecast = ZoneData(zone_data_path, ass_model.zone_numbers) 
+        # Set dist unit cost from zonedata
+        self.ass_model.dist_unit_cost = self.zdata_forecast.car_dist_cost
         # Output data
         self.resultmatrices = MatrixData(os.path.join(results_path, name, "Matrices"))
         self.resultdata = ResultsData(os.path.join(results_path, name))
@@ -94,7 +96,7 @@ class ModelSystem:
             self.logger.info("Assigning period " + tp)
             with self.basematrices.open("demand", tp) as mtx:
                 base_demand = {ass_class: mtx[ass_class] for ass_class in self.ass_classes}
-            self.ass_model.assign(tp, base_demand)
+            self.ass_model.assign(tp, base_demand, is_first_iteration=True)
             impedance[tp] = self.ass_model.get_impedance()
         return impedance
 

--- a/Scripts/tests/test_data/Base_input_data/2016_zonedata_test/2016.cco
+++ b/Scripts/tests/test_data/Base_input_data/2016_zonedata_test/2016.cco
@@ -1,2 +1,3 @@
 # Car usage cost [eur/km] 2030
+dist_cost
 0.12

--- a/Scripts/tests/test_data/Scenario_input_data/2030_test/2016.cco
+++ b/Scripts/tests/test_data/Scenario_input_data/2030_test/2016.cco
@@ -1,2 +1,3 @@
 # Car usage cost [eur/km] 2030
+dist_cost
 0.12


### PR DESCRIPTION
* Add car distance cost from zonedata
* Creating EmmeAssignment instance needs to be adjusted. Zonedata is read from modelsystem.py only after EmmeAssignment is initialized and assignment instance variable (number of zones) is used when reading zone data.
 * Changed Emme-network attributes and background variables to be prepared only when base assignment is performed. Using also is_first_iteration variable as a substitute for has_assigned_bike_and_walk as it is more understandable way of handling same issue.
* Fix Zonedata as the self.car_dist_cost was returning header instead of value.

Could @TimoElolahde check this Pull Request as I think Jens is unavailable. I did test run already with these changes and everything seems to be working fine.