### PR TITLE
Fix prepare_network call

### DIFF
--- a/Scripts/assignment/abstract_assignment.py
+++ b/Scripts/assignment/abstract_assignment.py
@@ -57,3 +57,7 @@ class ImpedanceSource:
     @abstractmethod
     def print_vehicle_kms(self, resultdatawriter):
         pass
+    
+    @abstractmethod
+    def prepare_network(self):
+        pass

--- a/Scripts/assignment/emme_assignment.py
+++ b/Scripts/assignment/emme_assignment.py
@@ -45,7 +45,7 @@ class EmmeAssignmentModel(AssignmentModel, ImpedanceSource):
             "iht": first_scenario_id+4,
         }
 
-    def _prepare_network(self):
+    def prepare_network(self):
         """Create extra attributes and calc backgroud variables for assignment."""
         self.create_attributes(self.bike_scenario, param.bike_attributes)
         self.create_attributes(self.day_scenario, param.emme_attributes)
@@ -72,7 +72,6 @@ class EmmeAssignmentModel(AssignmentModel, ImpedanceSource):
         self.set_emmebank_matrices(matrices)
         scen_id = self.emme_scenarios[time_period]
         if is_first_iteration:
-            self._prepare_network()
             self._assign_pedestrians(scen_id)
             self._assign_bikes(self.bike_scenario,
                             self.result_mtx["dist"]["bike"]["id"],

--- a/Scripts/assignment/mock_assignment.py
+++ b/Scripts/assignment/mock_assignment.py
@@ -87,3 +87,6 @@ class MockAssignmentModel(AssignmentModel, ImpedanceSource):
 
     def print_vehicle_kms(self, resultdata):
         pass
+
+    def prepare_network(self):
+        pass

--- a/Scripts/modelsystem.py
+++ b/Scripts/modelsystem.py
@@ -79,6 +79,9 @@ class ModelSystem:
     def assign_base_demand(self, use_fixed_transit_cost=False):
         impedance = {}
 
+        # create attributes and background variables to network
+        self.ass_model.prepare_network()
+
         # Calculate transit cost matrix, and save it to emmebank
         with self.basematrices.open("cost", "peripheral") as peripheral_mtx:
             peripheral_cost = peripheral_mtx["transit"]


### PR DESCRIPTION
* Fixes error I made with previous update.
* Call specify_network before transit cost assignment.
* No need to call creation of background variables on every time period.