### PR TITLE
Fix zonedata value types

### DIFF
--- a/Scripts/datahandling/zonedata.py
+++ b/Scripts/datahandling/zonedata.py
@@ -31,8 +31,17 @@ class ZoneData:
         cardata = read_csv_file(data_dir, ".car", self.zone_numbers)
         parkdata = read_csv_file(data_dir, ".prk", self.zone_numbers)
         self.externalgrowth = read_csv_file(data_dir, ".ext", external_zones)
+        for frame in [popdata, workdata, schooldata, landdata, parkdata, self.externalgrowth]:
+            try:
+                frame = frame.astype(dtype=float, errors='raise')
+            except ValueError:
+                raise ValueError("Zonedata file {} has values not convertible to floats.".format(frame.name))
         transit_zone = {}
         transit = read_csv_file(data_dir, ".tco")
+        try:
+            transit["fare"] = transit["fare"].astype(dtype=float, errors='raise')
+        except ValueError:
+            raise ValueError("Zonedata file .tco has fare values not convertible to floats.")
         transit_zone["fare"] = transit["fare"].to_dict()
         transit_zone["exclusive"] = transit["exclusive"].dropna().to_dict()
         transit_zone["dist_fare"] = transit_zone["fare"].pop("dist")

--- a/Scripts/utils/read_csv_file.py
+++ b/Scripts/utils/read_csv_file.py
@@ -38,6 +38,7 @@ def read_csv_file(data_dir, file_end, zone_numbers=None, squeeze=False):
     data = pandas.read_csv(
         path, delim_whitespace=True, squeeze=squeeze, keep_default_na=False,
         na_values="", comment='#', header=header)
+    data.name = file_end
     if data.index.is_numeric() and data.index.hasnans:
         raise IndexError("Row with only spaces or tabs in file {}".format(path))
     else:


### PR DESCRIPTION
* Python 2.7 performs automatically rounding to nearest integer when diving integer values (integer division). This causes calculating growth shares of population on car density change model to result only zeros.
* This fix converts all numeric Zonedata values to floats to prevent latent integer divisions in model-system.
* Simultaneously check Zonedata values and raise ValueErrors.