### PR TITLE
Remove fixed scenario ids

### DIFF
--- a/Scripts/assignment/departure_time.py
+++ b/Scripts/assignment/departure_time.py
@@ -4,7 +4,7 @@ import parameters as param
 
 
 class DepartureTimeModel:
-    def __init__(self, nr_zones):
+    def __init__(self, nr_zones, emme_scenarios):
         """Container for time period and assignment class specific demand.
         
         Parameters
@@ -13,7 +13,8 @@ class DepartureTimeModel:
             Number of zones in assignment model
         """
         self.nr_zones = nr_zones
-        self.demand = dict.fromkeys(param.emme_scenario)
+        self.emme_scenarios = emme_scenarios
+        self.demand = dict.fromkeys(self.emme_scenarios)
         for time_period in self.demand:
             ass_classes = dict.fromkeys(param.transport_classes)
             self.demand[time_period] = ass_classes
@@ -24,7 +25,7 @@ class DepartureTimeModel:
 
     def init_demand(self):
         """Initialize/reset demand for all time periods (each including transport_classes, each being set to zeros)."""
-        self.demand = dict.fromkeys(param.emme_scenario)
+        self.demand = dict.fromkeys(self.emme_scenarios)
         for time_period in self.demand:
             ass_classes = dict.fromkeys(param.transport_classes)
             self.demand[time_period] = ass_classes
@@ -47,13 +48,13 @@ class DepartureTimeModel:
                 ass_class = demand.mode
             if len(demand.position) == 2:
                 share = param.demand_share[demand.purpose.name][demand.mode]
-                for time_period in param.emme_scenario:
+                for time_period in self.emme_scenarios:
                     self._add_2d_demand(
                         share[time_period], ass_class, time_period,
                         demand.matrix, demand.position)
                 self.logger.debug("Added demand for {}, {}".format(demand.purpose.name, demand.mode))
             elif len(demand.position) == 3:
-                for time_period in param.emme_scenario:
+                for time_period in self.emme_scenarios:
                     self._add_3d_demand(demand, ass_class, time_period)
                 self.logger.debug("Added demand for {}, {}, {}".format(demand.purpose.name, demand.mode, demand.orig))
             else:

--- a/Scripts/assignment/emme_assignment.py
+++ b/Scripts/assignment/emme_assignment.py
@@ -291,8 +291,8 @@ class EmmeAssignmentModel(AssignmentModel, ImpedanceSource):
             kms[ass_class] = dict.fromkeys(vdfs, 0)
         transit_dists = dict.fromkeys(transit_modes, 0)
         transit_times = dict.fromkeys(transit_modes, 0)
-        for tp in param.emme_scenario:
-            scen_id = param.emme_scenario[tp]
+        for tp in self.emme_scenarios:
+            scen_id = self.emme_scenarios[tp]
             scen = self.emme_project.modeller.emmebank.scenario(scen_id)
             network = scen.get_network()
             for link in network.links():

--- a/Scripts/assignment/mock_assignment.py
+++ b/Scripts/assignment/mock_assignment.py
@@ -9,6 +9,7 @@ class MockAssignmentModel(AssignmentModel, ImpedanceSource):
         self.logger = logging.getLogger()
         self.logger.info("Reading matrices from " + str(self.matrices.path))
         self.result_mtx=param.emme_result_mtx
+        self.emme_scenarios = {"aht": 21, "pt": 22, "iht": 23}
     
     def assign(self, time_period, matrices, is_last_iteration=False, is_first_iteration=False):
         """Assign cars, bikes and transit for one time period.

--- a/Scripts/cba.py
+++ b/Scripts/cba.py
@@ -27,6 +27,7 @@ def run_cost_benefit_analysis(scenario_0, scenario_1, year, results_directory):
     excelfile = os.path.join(SCRIPT_DIR, "CBA_kehikko.xlsx")
     mile_diff = read_miles(results_directory, scenario_1) - read_miles(results_directory, scenario_0)
     transit_mile_diff = read_transit_miles(results_directory, scenario_1) - read_transit_miles(results_directory, scenario_0)
+    emme_scenarios = ["aht", "pt", "iht"]
     revenues = {
         "car": {},
         "transit": {},
@@ -34,7 +35,7 @@ def run_cost_benefit_analysis(scenario_0, scenario_1, year, results_directory):
     gains = dict.fromkeys(param.transport_classes)
     for transport_class in gains:
         gains[transport_class] = {}
-    for tp in param.emme_scenario:
+    for tp in emme_scenarios:
         ve1 = read_scenario(os.path.join(results_directory, scenario_1, "Matrices"), tp)
         ve0 = read_scenario(os.path.join(results_directory, scenario_0, "Matrices"), tp)
         revenues["transit"][tp] = 0

--- a/Scripts/parameters.py
+++ b/Scripts/parameters.py
@@ -104,12 +104,7 @@ bike_dist = {
 # Volume-delay function files
 func_car = "d411_pituusriippuvaiset_HM30.in"
 func_bike = "d411_pituusriippuvaiset_pyora.in"
-# Emme scenarios used in assignment
-emme_scenario = {
-    "aht": 21,
-    "pt": 22,
-    "iht": 23,
-}
+
 transport_classes = (
     "car_work",
     "car_leisure",

--- a/Scripts/tests/integration/test_data_handling.py
+++ b/Scripts/tests/integration/test_data_handling.py
@@ -30,7 +30,8 @@ class MatrixDataTest(unittest.TestCase):
             self._validate_matrix_operations(m, matrix_type)
 
     def _validate_matrix_operations(self, matrix_data, matrix_type):
-        for key in params.emme_scenario.keys():
+        emme_scenarios = ["aht", "pt", "iht"]
+        for key in emme_scenarios:
             print("Opening matrix for time period", key)
             with matrix_data.open(matrix_type, time_period=key) as mtx:
                 self.assertIsNotNone(mtx._file)

--- a/Scripts/tests/integration/test_models.py
+++ b/Scripts/tests/integration/test_models.py
@@ -23,7 +23,7 @@ class ModelTest(unittest.TestCase):
         # model.dm.create_population()
         # self.assertEqual(7, len(ass_classes))
         impedance = model.assign_base_demand()
-        for tp in parameters.emme_scenario:
+        for tp in ass_model.emme_scenarios:
             print("Validating impedance")
             self.assertEqual(3, len(impedance[tp]))
             self.assertIsNotNone(impedance[tp]["time"])
@@ -34,7 +34,7 @@ class ModelTest(unittest.TestCase):
         impedance = model.run_iteration(impedance)
         # for mode in demand:
         #     self._validate_demand(demand[mode])
-        self.assertEquals(len(parameters.emme_scenario), len(impedance))
+        self.assertEquals(len(ass_model.emme_scenarios), len(impedance))
         self._validate_impedances(impedance["aht"])
         self._validate_impedances(impedance["pt"])
         self._validate_impedances(impedance["iht"])

--- a/Scripts/tests/unit/test_departure_time.py
+++ b/Scripts/tests/unit/test_departure_time.py
@@ -7,7 +7,8 @@ from assignment.departure_time import DepartureTimeModel
 
 class DepartureTimeTest(unittest.TestCase):
     def test_mtx_add(self):
-        dtm = DepartureTimeModel(8)
+        emme_scenarios = {"aht": 21, "pt": 22, "iht": 23}
+        dtm = DepartureTimeModel(8, emme_scenarios)
         mtx = numpy.arange(9)
         mtx.shape = (3, 3)
         class Demand:


### PR DESCRIPTION
* Currently method print_vehicle_kms uses fixed scenario ids (21-23). However these should be set by user via selecting first_scenario_id
* This fix removes emme_scenario variable from parameters as this should not be used as fixed variable in any case
* Emme-scenarios are set in Emme-assignment. Classes modelsystem and departure_time are set to use this instance variable

Fyi @samakinen if you're currently working with CBA