### PR TITLE
Update logging and log.py

### DIFF
--- a/Scripts/assignment/departure_time.py
+++ b/Scripts/assignment/departure_time.py
@@ -52,7 +52,6 @@ class DepartureTimeModel:
                     self._add_2d_demand(
                         share[time_period], ass_class, time_period,
                         demand.matrix, demand.position)
-                self.logger.debug("Added demand for {}, {}".format(demand.purpose.name, demand.mode))
             elif len(demand.position) == 3:
                 for time_period in self.emme_scenarios:
                     self._add_3d_demand(demand, ass_class, time_period)

--- a/Scripts/assignment/departure_time.py
+++ b/Scripts/assignment/departure_time.py
@@ -55,7 +55,6 @@ class DepartureTimeModel:
             elif len(demand.position) == 3:
                 for time_period in self.emme_scenarios:
                     self._add_3d_demand(demand, ass_class, time_period)
-                self.logger.debug("Added demand for {}, {}, {}".format(demand.purpose.name, demand.mode, demand.orig))
             else:
                 raise IndexError("Tuple position has wrong dimensions.")
 

--- a/Scripts/utils/log.py
+++ b/Scripts/utils/log.py
@@ -43,7 +43,7 @@ class Log:
             file = Config.DefaultScenario + '.log'
         self._filename = os.path.join(sys.path[0], file)
         fileFormat = logging.Formatter('%(asctime)s [%(levelname)s] %(message)s')
-        fileHandler = logging.handlers.TimedRotatingFileHandler(self._filename, when='midnight', backupCount=7)
+        fileHandler = logging.handlers.TimedRotatingFileHandler(self._filename, when='H', interval=10, backupCount=7)
         fileHandler.setFormatter(fileFormat)
         fileHandler.setLevel(numeric_level)
         self.__logger.addHandler(fileHandler)


### PR DESCRIPTION
This Pull Request has minor fixes to improve usability of logging messages:
* Remove add_demand debug message from SecDests as it makes log files unreadable when opening via Emme Logbooks (currently prints one row for each origin and trip purpose).
* Rotate file with 10 hour time interval instead of midnight. There is no need to rotate at midnight as usually we run do model runs overnight and would prefer to keep one model run in same log file. Total length of log file is reasonable even if file is not rotated.