### PR TITLE
Stopping criteria for congested transit assignment

### DIFF
--- a/Scripts/parameters.py
+++ b/Scripts/parameters.py
@@ -76,7 +76,7 @@ trass_func = {
 }
 # Stopping criteria for congested transit assignment
 trass_stop = {
-    "max_iterations": 10,
+    "max_iterations": 50,
     "normalized_gap": 0.01,
     "relative_gap": 0.001
 }


### PR DESCRIPTION
* Change max_iterations to 50. Congested assignment is not well converged with 10 iterations, which causes CBA to show large differences in transit user benefits.
* Most cases end with normalized_gap around 30-35 iteration rounds and at this stage CBA-user benefits are converged.
* This update ensures that even most difficult model runs end with gap-criteria instead of no. rounds.