### PR TITLE
Fix/aggregation of car results

### DIFF
--- a/Scripts/models/linear.py
+++ b/Scripts/models/linear.py
@@ -87,11 +87,9 @@ class CarDensityModel(LinearModel):
     def print_results(self, prediction):
         """ Print results, mainly for calibration purposes"""
 
-        # In validation data, car user shares are calculated for people
-        # over 6 years old (like HEHA).
-        population = self.zone_data["population"]
-        population_7_99 = ( population[:self.zone_data.first_peripheral_zone]
-                          * self.zone_data["share_age_7-99"])
+        # In validation data, car density is calculated for the whole
+        # population from ages 0 to 999.
+        population = self.zone_data["population"][:self.zone_data.first_peripheral_zone]
         car_density = prediction
                 
         # Print car density by zone
@@ -105,7 +103,7 @@ class CarDensityModel(LinearModel):
             i = slice(parameters.municipality[municipality][0],
                       parameters.municipality[municipality][1])
             x = car_density.loc[i]
-            w = population_7_99.loc[i]
+            w = population.loc[i]
             prediction_municipality.append((x * w).sum() / w.sum())
         self.resultdata.print_data(
             prediction_municipality, "car_density_per_municipality.txt",
@@ -117,7 +115,7 @@ class CarDensityModel(LinearModel):
             i = slice(parameters.areas[area][0],
                       parameters.areas[area][1])
             x = car_density.loc[i]
-            w = population_7_99.loc[i]
+            w = population.loc[i]
             prediction_area.append((x * w).sum() / w.sum())
         self.resultdata.print_data(
             prediction_area, "car_density_per_area.txt",

--- a/Scripts/models/logit.py
+++ b/Scripts/models/logit.py
@@ -781,11 +781,15 @@ class CarUseModel(LogitModel):
     def print_results(self, prob):
         """ Print results, mainly for calibration purposes"""
         population = self.zone_data["population"]
-        population_7_99 = (population[:self.zone_data.first_peripheral_zone] * self.zone_data["share_age_7-99"])
+        population_7_99 = ( population[:self.zone_data.first_peripheral_zone]
+                          * self.zone_data["share_age_7-99"] )
         car_users = prob * population_7_99
                 
         # Print car user share by zone
-        self.resultdata.print_data(prob, "car_use.txt", self.zone_data.zone_numbers[self.bounds], "car_use")
+        self.resultdata.print_data(prob,
+                                   "car_use.txt",
+                                   self.zone_data.zone_numbers[self.bounds],
+                                   "car_use")
         
         # print car use share by municipality
         prob_municipality = []
@@ -795,7 +799,10 @@ class CarUseModel(LogitModel):
             # comparison data has car user shares of population
             # over 6 years old (from HEHA)
             prob_municipality.append(car_users.loc[i].sum() / population_7_99.loc[i].sum())
-        self.resultdata.print_data(prob_municipality, "car_use_per_municipality.txt", parameters.municipality.keys(), "car_use")
+        self.resultdata.print_data(prob_municipality,
+                                   "car_use_per_municipality.txt",
+                                   parameters.municipality.keys(),
+                                   "car_use")
                           
         # print car use share by area (to get Helsinki CBD vs. Helsinki other)
         prob_area = []
@@ -805,4 +812,7 @@ class CarUseModel(LogitModel):
             # comparison data has car user shares of population
             # over 6 years old (from HEHA)
             prob_area.append(car_users.loc[i].sum() / population_7_99.loc[i].sum())
-        self.resultdata.print_data(prob_area, "car_use_per_area.txt", parameters.areas.keys(), "car_use")
+        self.resultdata.print_data(prob_area,
+                                   "car_use_per_area.txt",
+                                   parameters.areas.keys(),
+                                   "car_use")


### PR DESCRIPTION
In this PR, the aggregation weights of car density are changed from 6-99-year-olds to the whole population. I think the 6-99-year-olds were there previously because they are used in car user shares (the amount of car drivers per 6-99-year-old population, HAP/EHAP model).
