### PR TITLE
Car assignment before transit cost calculation

### DIFF
--- a/Scripts/modelsystem.py
+++ b/Scripts/modelsystem.py
@@ -87,6 +87,9 @@ class ModelSystem:
         self.ass_model.prepare_network()
 
         # Calculate transit cost matrix, and save it to emmebank
+        with self.basematrices.open("demand", "aht") as mtx:
+            base_demand = {ass_class: mtx[ass_class] for ass_class in self.ass_classes}
+        self.ass_model.assign("aht", base_demand, is_first_iteration=True)
         with self.basematrices.open("cost", "peripheral") as peripheral_mtx:
             peripheral_cost = peripheral_mtx["transit"]
             if use_fixed_transit_cost:


### PR DESCRIPTION
* Base car assignment should be done before transit cost calculation as speed of buses is dependent of link speeds produced by car assignment.
* WIthout this fix assignment bus travel times can be reasonable (previous assignment done on network), infinite or zero (if network is initialized before model run).
* This is quick fix. This needs to be changed later so that car assignment is performed only once. However, this requires refactoring of Emme-assignment methods.