### PR TITLE
Expand peak hours to day volumes

### DIFF
--- a/Scripts/assignment/emme_assignment.py
+++ b/Scripts/assignment/emme_assignment.py
@@ -83,7 +83,7 @@ class EmmeAssignmentModel(AssignmentModel, ImpedanceSource):
         elif is_last_iteration:
             self._assign_cars(scen_id, param.stopping_criteria_fine)
             self._calc_extra_wait_time(scen_id)
-            # self._assign_congested_transit(scen_id)
+            self._assign_congested_transit(scen_id)
             self._assign_bikes(self.bike_scenario,
                            self.result_mtx["dist"]["bike"]["id"],
                            "all",

--- a/Scripts/emme_bindings/emme_project.py
+++ b/Scripts/emme_bindings/emme_project.py
@@ -43,6 +43,8 @@ class EmmeProject:
             "inro.emme.transit_assignment.extended.matrix_results")
         self.create_extra_attribute = self.modeller.tool(
             "inro.emme.data.extra_attribute.create_extra_attribute")
+        self.network_results = self.modeller.tool(
+            "inro.emme.transit_assignment.extended.network_results")
     
     def write(self, message):
         """Write to logbook."""

--- a/Scripts/parameters.py
+++ b/Scripts/parameters.py
@@ -174,11 +174,15 @@ emme_attributes = {
     "@trailer_truck": "LINK",
     "@truck": "LINK",
     "@van": "LINK", 
+    "@transit_vol": "TRANSIT_SEGMENT",
+    "@transit_boa": "TRANSIT_SEGMENT",
+    "@transit_trb": "TRANSIT_SEGMENT",
 }
 bike_attributes = {
     "@bike_aht": "LINK",
     "@bike_iht": "LINK",
     "@bike_pt": "LINK",
+    "@bike_day": "LINK",
 }
 transit_assignment_modes = transit_modes + aux_modes
 # Link attribute for volumes


### PR DESCRIPTION
* Add expand methods to Emme Assignment. The 24h expansions is calculated during last iteration
* Save volumes for different car classes, transit volumes and boardings and bikes
* Transit results use modeller tool Network results, so this is added to Emme bindings
* Add required extra attributes to parameters.py