### PR TITLE
Parking norm possible to define manually

### DIFF
--- a/Scripts/datahandling/zonedata.py
+++ b/Scripts/datahandling/zonedata.py
@@ -29,31 +29,28 @@ class ZoneData:
         schooldata = read_csv_file(data_dir, ".edu", self.zone_numbers)
         landdata = read_csv_file(data_dir, ".lnd", self.zone_numbers)
         parkdata = read_csv_file(data_dir, ".prk", self.zone_numbers)
+        self.externalgrowth = read_csv_file(data_dir, ".ext", external_zones)
+        transit = read_csv_file(data_dir, ".tco")
+        for frame in [popdata, workdata, schooldata, landdata, parkdata,
+                      self.externalgrowth, transit["fare"]]:
+            try:
+                frame = frame.astype(dtype=float, errors='raise')
+            except ValueError:
+                raise ValueError("Zone data file {} has values not convertible to floats.".format(frame.name))
+        transit_zone = {}
+        transit_zone["fare"] = transit["fare"].to_dict()
+        try:
+            transit_zone["exclusive"] = transit["exclusive"].dropna().to_dict()
+        except KeyError:
+            transit_zone["exclusive"] = {}
+        transit_zone["dist_fare"] = transit_zone["fare"].pop("dist")
+        transit_zone["start_fare"] = transit_zone["fare"].pop("start")
+        self.transit_zone = transit_zone
         try:
             cardata = read_csv_file(data_dir, ".car")
             self["parking_norm"] = cardata["prknorm"]
         except (NameError, KeyError):
             self._values["parking_norm"] = None
-        self.externalgrowth = read_csv_file(data_dir, ".ext", external_zones)
-        for frame in [popdata, workdata, schooldata, landdata, parkdata, self.externalgrowth]:
-            try:
-                frame = frame.astype(dtype=float, errors='raise')
-            except ValueError:
-                raise ValueError("Zonedata file {} has values not convertible to floats.".format(frame.name))
-        transit_zone = {}
-        transit = read_csv_file(data_dir, ".tco")
-        try:
-            transit["fare"] = transit["fare"].astype(dtype=float, errors='raise')
-        except ValueError:
-            raise ValueError("Zonedata file .tco has fare values not convertible to floats.")
-        transit_zone["fare"] = transit["fare"].to_dict()
-        try:
-            transit_zone["exclusive"] = transit["exclusive"].dropna().to_dict()
-        except KeyError:
-            transit_zone["exclusive"] ={}
-        transit_zone["dist_fare"] = transit_zone["fare"].pop("dist")
-        transit_zone["start_fare"] = transit_zone["fare"].pop("start")
-        self.transit_zone = transit_zone
         car_cost = read_csv_file(data_dir, ".cco", squeeze=False)
         self.car_dist_cost = car_cost["dist_cost"][0]
         truckdata = read_csv_file(data_dir, ".trk", squeeze=True)

--- a/Scripts/datahandling/zonedata.py
+++ b/Scripts/datahandling/zonedata.py
@@ -42,7 +42,10 @@ class ZoneData:
         except ValueError:
             raise ValueError("Zonedata file .tco has fare values not convertible to floats.")
         transit_zone["fare"] = transit["fare"].to_dict()
-        transit_zone["exclusive"] = transit["exclusive"].dropna().to_dict()
+        try:
+            transit_zone["exclusive"] = transit["exclusive"].dropna().to_dict()
+        except KeyError:
+            transit_zone["exclusive"] ={}
         transit_zone["dist_fare"] = transit_zone["fare"].pop("dist")
         transit_zone["start_fare"] = transit_zone["fare"].pop("start")
         self.transit_zone = transit_zone

--- a/Scripts/datahandling/zonedata.py
+++ b/Scripts/datahandling/zonedata.py
@@ -25,19 +25,17 @@ class ZoneData:
         first_external = numpy.where(zone_numbers >= external[0])[0][0]
         self.first_external_zone = first_external
         external_zones = zone_numbers[first_external:]
-        popdata = read_csv_file(data_dir, ".pop", self.zone_numbers)
-        workdata = read_csv_file(data_dir, ".wrk", self.zone_numbers)
-        schooldata = read_csv_file(data_dir, ".edu", self.zone_numbers)
-        landdata = read_csv_file(data_dir, ".lnd", self.zone_numbers)
-        parkdata = read_csv_file(data_dir, ".prk", self.zone_numbers)
-        self.externalgrowth = read_csv_file(data_dir, ".ext", external_zones)
+        popdata = read_csv_file(data_dir, ".pop", self.zone_numbers, float)
+        workdata = read_csv_file(data_dir, ".wrk", self.zone_numbers, float)
+        schooldata = read_csv_file(data_dir, ".edu", self.zone_numbers, float)
+        landdata = read_csv_file(data_dir, ".lnd", self.zone_numbers, float)
+        parkdata = read_csv_file(data_dir, ".prk", self.zone_numbers, float)
+        self.externalgrowth = read_csv_file(data_dir, ".ext", external_zones, float)
         transit = read_csv_file(data_dir, ".tco")
-        for frame in [popdata, workdata, schooldata, landdata, parkdata,
-                      self.externalgrowth, transit["fare"]]:
-            try:
-                frame = frame.astype(dtype=float, errors='raise')
-            except ValueError:
-                raise ValueError("Zone data file {} has values not convertible to floats.".format(frame.name))
+        try:
+            transit["fare"] = transit["fare"].astype(dtype=float, errors='raise')
+        except ValueError:
+            raise ValueError("Zonedata file .tco has fare values not convertible to floats.")
         transit_zone = {}
         transit_zone["fare"] = transit["fare"].to_dict()
         try:

--- a/Scripts/datahandling/zonedata.py
+++ b/Scripts/datahandling/zonedata.py
@@ -29,6 +29,11 @@ class ZoneData:
         schooldata = read_csv_file(data_dir, ".edu", self.zone_numbers)
         landdata = read_csv_file(data_dir, ".lnd", self.zone_numbers)
         parkdata = read_csv_file(data_dir, ".prk", self.zone_numbers)
+        try:
+            cardata = read_csv_file(data_dir, ".car")
+            self["parking_norm"] = cardata["prknorm"]
+        except (NameError, KeyError):
+            self._values["parking_norm"] = None
         self.externalgrowth = read_csv_file(data_dir, ".ext", external_zones)
         for frame in [popdata, workdata, schooldata, landdata, parkdata, self.externalgrowth]:
             try:

--- a/Scripts/demand/trips.py
+++ b/Scripts/demand/trips.py
@@ -95,7 +95,7 @@ class DemandModel:
                 share = self.zone_data[key][idx]
                 weights.append(share)
                 weights[0] -= share
-            for _ in xrange(0, self.zone_data["population"][idx]):
+            for _ in xrange(0, int(self.zone_data["population"][idx])):
                 a = numpy.arange(-1, len(self.age_groups))
                 group = numpy.random.choice(a=a, p=weights)
                 if group != -1:

--- a/Scripts/parameters.py
+++ b/Scripts/parameters.py
@@ -2922,7 +2922,7 @@ car_usage = {
 car_density = {
     "constant": 0.0,
     "generation": {
-        "share_detached_houses": 2.523e-01, # Originally estimated for percentages (0-100), here transformed
+        "share_detached_houses_new": 2.523e-01, # Originally estimated for percentages (0-100), here transformed
         "helsinki": 3.782e-02,
         "surrounding": 5.043e-02,
     },

--- a/Scripts/tests/integration/test_models.py
+++ b/Scripts/tests/integration/test_models.py
@@ -37,7 +37,7 @@ class ModelTest(unittest.TestCase):
         self._validate_impedances(impedance["iht"])
 
         # Check that model result does not change
-        self.assertAlmostEquals(model.mode_share[0]["car"], 0.56742957061235355)
+        self.assertAlmostEquals(model.mode_share[0]["car"], 0.5576934871486231)
         
         print("Model system test done")
     

--- a/Scripts/tests/integration/test_models.py
+++ b/Scripts/tests/integration/test_models.py
@@ -20,8 +20,6 @@ class ModelTest(unittest.TestCase):
         base_matrices_path = os.path.join(TEST_DATA_PATH, "Base_input_data", "base_matrices_test")
         results_path = os.path.join(TEST_DATA_PATH, "Results")
         model = ModelSystem(zone_data_path, base_zone_data_path, base_matrices_path, results_path, ass_model, "test")
-        # model.dm.create_population()
-        # self.assertEqual(7, len(ass_classes))
         impedance = model.assign_base_demand()
         for tp in ass_model.emme_scenarios:
             print("Validating impedance")
@@ -32,14 +30,16 @@ class ModelTest(unittest.TestCase):
             
         print("Adding demand and assigning")
         impedance = model.run_iteration(impedance)
-        # for mode in demand:
-        #     self._validate_demand(demand[mode])
+
         self.assertEquals(len(ass_model.emme_scenarios), len(impedance))
         self._validate_impedances(impedance["aht"])
         self._validate_impedances(impedance["pt"])
         self._validate_impedances(impedance["iht"])
+
+        # Check that model result does not change
+        self.assertAlmostEquals(model.mode_share[0]["car"], 0.61480569288504772)
         
-        print("Assignment test done")
+        print("Model system test done")
     
     def test_agent_model(self):
         ass_model = MockAssignmentModel(MatrixData(os.path.join(TEST_DATA_PATH, "Results", "test", "Matrices")))

--- a/Scripts/tests/integration/test_models.py
+++ b/Scripts/tests/integration/test_models.py
@@ -37,7 +37,7 @@ class ModelTest(unittest.TestCase):
         self._validate_impedances(impedance["iht"])
 
         # Check that model result does not change
-        self.assertAlmostEquals(model.mode_share[0]["car"], 0.5576934871486231)
+        self.assertAlmostEquals(model.mode_share[0]["car"], 0.51446995351699742)
         
         print("Model system test done")
     

--- a/Scripts/tests/integration/test_models.py
+++ b/Scripts/tests/integration/test_models.py
@@ -37,7 +37,7 @@ class ModelTest(unittest.TestCase):
         self._validate_impedances(impedance["iht"])
 
         # Check that model result does not change
-        self.assertAlmostEquals(model.mode_share[0]["car"], 0.61480569288504772)
+        self.assertAlmostEquals(model.mode_share[0]["car"], 0.56742957061235355)
         
         print("Model system test done")
     

--- a/Scripts/tests/test_data/Base_input_data/2016_zonedata_test/2016.lnd
+++ b/Scripts/tests/test_data/Base_input_data/2016_zonedata_test/2016.lnd
@@ -1,7 +1,7 @@
 # Land use 2030
 #
 # builtar: area of built environment
-# detach: detached houses as share of total number of houses
+# detach: detached houses as share of total building area of houses
 #
 	builtar	detach
 5	5       0.1
@@ -9,4 +9,4 @@
 7	10	0.3
 2792	5       0.4
 16001	15	0.5
-17000	10	10
+17000	10	1.0

--- a/Scripts/tests/test_data/Scenario_input_data/2030_test/2016.lnd
+++ b/Scripts/tests/test_data/Scenario_input_data/2030_test/2016.lnd
@@ -1,7 +1,7 @@
 # Land use 2030
 #
 # builtar: area of built environment
-# detach: detached houses as share of total number of houses
+# detach: detached houses as share of total building area of houses
 #
 	builtar	detach
 5	5       0.1
@@ -9,4 +9,4 @@
 7	10	0.3
 2792	5       0.4
 16001	15	0.5
-17000	10	10
+17000	10	1.0

--- a/Scripts/utils/read_csv_file.py
+++ b/Scripts/utils/read_csv_file.py
@@ -3,7 +3,7 @@ import pandas
 import numpy
 
 
-def read_csv_file(data_dir, file_end, zone_numbers=None, squeeze=False):
+def read_csv_file(data_dir, file_end, zone_numbers=None, dtype=None, squeeze=False):
     """Read (zone) data from space-separated file.
     
     Parameters
@@ -14,6 +14,8 @@ def read_csv_file(data_dir, file_end, zone_numbers=None, squeeze=False):
         Ending of the file in question (e.g., ".pop")
     zone_numbers : ndarray (optional)
         Zone numbers to compare with for validation
+    dtype : data type (optional)
+        Data type to cast data to
     squeeze : bool (optional)
         If the parsed data only contains one column and no header
 
@@ -38,7 +40,6 @@ def read_csv_file(data_dir, file_end, zone_numbers=None, squeeze=False):
     data = pandas.read_csv(
         path, delim_whitespace=True, squeeze=squeeze, keep_default_na=False,
         na_values="", comment='#', header=header)
-    data.name = file_end
     if data.index.is_numeric() and data.index.hasnans:
         raise IndexError("Row with only spaces or tabs in file {}".format(path))
     else:
@@ -57,4 +58,9 @@ def read_csv_file(data_dir, file_end, zone_numbers=None, squeeze=False):
             for i in zone_numbers:
                 if i not in data.index:
                     raise IndexError("Zone number {} not found in file {}".format(i, path))
+    if dtype is not None:
+        try:
+            data = data.astype(dtype=dtype, errors='raise')
+        except ValueError:
+            raise ValueError("Zone data file {} has values not convertible to floats.".format(file_end))
     return data


### PR DESCRIPTION
Added possibility to have a .car file for forecast years (normally this file would exist only for base year and contain true car density) containing parking norms (unit: cars per inhabitant) in column _prknorm_. The file can contain values for a subset of the zones. 

The parking norm, when defined, will override modelled car densities for new inhabitants. Zones that are missing from the file will adopt modelled car densities.

Also made some other smaller adjustments and fixed bug in type casting in `ZoneData`.