### PR TITLE
Transit volume factors

### DIFF
--- a/Scripts/assignment/emme_assignment.py
+++ b/Scripts/assignment/emme_assignment.py
@@ -321,10 +321,10 @@ class EmmeAssignmentModel(AssignmentModel, ImpedanceSource):
                     if line.mode.id in transit_modes[modes]:
                         mode = modes
                 for segment in line.segments():
-                    transit_dists[mode] += (param.volume_factors["transit"][tp]
+                    transit_dists[mode] += (param.volume_factors["bus"][tp]
                                             * (60 / segment.line.headway)
                                             * segment.link.length)
-                    transit_times[mode] += (param.volume_factors["transit"][tp]
+                    transit_times[mode] += (param.volume_factors["bus"][tp]
                                             * (60 / segment.line.headway)
                                             * segment.transit_time)
         for ass_class in kms:

--- a/Scripts/parameters.py
+++ b/Scripts/parameters.py
@@ -191,7 +191,8 @@ link_volumes = {
     "car_leisure": "@car_leisure",
     "trailer_truck": "@trailer_truck",
     "truck": "@truck",
-    "van": "@van"
+    "van": "@van",
+    "bus": "@bus"
     }
 # Factors for 24-h expansion of volumes
 # TODO: Trucks and vans


### PR DESCRIPTION
* Transit dist and times to use volume_factors that represent transit supply (no departures from GTFS dump 12/2019).
* Now using one coefficient that represents all modes. These can be calculated by transit mode, but it might be unnecessary?
* Add "bus: @bus" to link_volumes so that 24h expansion is done for background bus traffic as well.