### PR TITLE
Loosen criteria for larger than one check to 1.001

### DIFF
--- a/Scripts/datahandling/zonedata.py
+++ b/Scripts/datahandling/zonedata.py
@@ -228,8 +228,8 @@ class ShareChecker:
         self.data = data
 
     def __setitem__(self, key, data):
-        if (data > 1).any():
+        if (data > 1.001).any():
             for (i, val) in data.iteritems():
-                if val > 1:
+                if val > 1.001:
                     raise ValueError("{} ({}) for zone {} is larger than one".format(key, val, i).capitalize())
         self.data[key] = data


### PR DESCRIPTION
As pointed out by @atte-wsp in https://github.com/HSLdevcom/helmet-model-system/pull/187#commitcomment-41748083, check was too strict when values are rounded.