### PR TITLE
Changed parameter syntax, allowing two years at once

### DIFF
--- a/Scripts/cba.py
+++ b/Scripts/cba.py
@@ -8,7 +8,7 @@ from argparse import ArgumentParser
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 
-def run_cost_benefit_analysis(scenario_0, scenario_1, year, results_directory):
+def run_cost_benefit_analysis(scenario_0, scenario_1, year, results_directory, workbook):
     """Runs CBA and writes the results to excel file.
 
     Parameters
@@ -23,8 +23,10 @@ def run_cost_benefit_analysis(scenario_0, scenario_1, year, results_directory):
         The evaluation year (1 or 2)
     results_directory : str
         Path to where "scenario_name/Matrices" result folder exists
+    workbook : openpyxl.WorkBook
+        The excel workbook where to save results
     """
-    excelfile = os.path.join(SCRIPT_DIR, "CBA_kehikko.xlsx")
+    wb = workbook
     mile_diff = read_miles(results_directory, scenario_1) - read_miles(results_directory, scenario_0)
     transit_mile_diff = read_transit_miles(results_directory, scenario_1) - read_transit_miles(results_directory, scenario_0)
     emme_scenarios = ["aht", "pt", "iht"]
@@ -50,17 +52,13 @@ def run_cost_benefit_analysis(scenario_0, scenario_1, year, results_directory):
             gains[transport_class][tp] = calc_gains(
                 ve0[transport_class], ve1[transport_class])
         print "Gains " + tp + " calculated"
-    wb = load_workbook(excelfile)
     if year == 1:
         write_results_1(wb, mile_diff, transit_mile_diff, revenues, gains)
     elif year == 2:
         write_results_2(wb, mile_diff, transit_mile_diff, revenues, gains)
     else:
         print "Evaluation year must be either 1 or 2"
-
-    results_filename =  "cba_{}_{}.xlsx".format(scenario_1, scenario_0)
-    wb.save(os.path.join(results_directory, scenario_1, results_filename))
-    print "CBA results saved to file: {}".format(results_filename)
+    
 
 
 def read_scenario(path, time_period):
@@ -332,9 +330,29 @@ def write_gains_2(ws, gains):
 if __name__ == "__main__":
     parser = ArgumentParser(epilog="Calculates the Cost-Benefit Analysis between Results of two HELMET-Scenarios, "
                                    "and writes the outcome in CBA_kehikko.xlsx -file (in same folder).")
-    parser.add_argument("baseline_scenario", type=str, help="A 'do-nothing' baseline scenario.")
-    parser.add_argument("projected_scenario", type=str, help="A projected scenario, compared to the baseline scenario.")
-    parser.add_argument("evaluation_year", type=int, choices={1, 2}, help="Evaluation year, either 1 or 2.")
-    parser.add_argument("--results-path", dest="results_path", type=str, required=True, help="Path to Results directory.")
+    parser.add_argument(
+        "baseline_scenario", type=str, help="A 'do-nothing' baseline scenario")
+    parser.add_argument(
+        "projected_scenario", type=str,
+        help="A projected scenario, compared to the baseline scenario")
+    parser.add_argument(
+        "baseline_scenario_2", nargs='?', type=str,
+        help="A 'do-nothing' baseline scenario for second forecast year (optional)")
+    parser.add_argument(
+        "projected_scenario_2", nargs='?', type=str,
+        help="A projected scenario, compared to the baseline scenario for second forecast year (optional)")
+    parser.add_argument(
+        "--results-path", dest="results_path", type=str, required=True,
+        help="Path to Results directory.")
     args = parser.parse_args()
-    run_cost_benefit_analysis(args.baseline_scenario, args.projected_scenario, args.evaluation_year, args.results_path)
+    wb = load_workbook(os.path.join(SCRIPT_DIR, "CBA_kehikko.xlsx"))
+    run_cost_benefit_analysis(
+        args.baseline_scenario, args.projected_scenario, 1, args.results_path, wb)
+    if args.baseline_scenario_2 is not None and args.baseline_scenario_2 != "undefined":
+        run_cost_benefit_analysis(
+            args.baseline_scenario_2, args.projected_scenario_2, 2, args.results_path, wb)
+    results_filename =  "cba_{}_{}.xlsx".format(
+        os.path.basename(args.projected_scenario),
+        os.path.basename(args.baseline_scenario))
+    wb.save(os.path.join(args.results_path, results_filename))
+    print "CBA results saved to file: {}".format(results_filename)


### PR DESCRIPTION
In connection with some changes in the UI (https://github.com/HSLdevcom/helmet-ui/pull/31), this makes cba with two forecast years much more simple to perform.