### PR TITLE
ShareChecker condition

### DIFF
--- a/Scripts/datahandling/zonedata.py
+++ b/Scripts/datahandling/zonedata.py
@@ -228,8 +228,8 @@ class ShareChecker:
         self.data = data
 
     def __setitem__(self, key, data):
-        if (data > 1.001).any():
+        if (data > 1.005).any():
             for (i, val) in data.iteritems():
-                if val > 1.001:
+                if val > 1.005:
                     raise ValueError("{} ({}) for zone {} is larger than one".format(key, val, i).capitalize())
         self.data[key] = data


### PR DESCRIPTION
* Small change because MAL2019 population and age group data still has some rounding issues 
* This allows 0.001 rounding errors in each age group so MAL2019 forecast zonedata can be used without modifications