### PR TITLE
Transit generation calibration

### DIFF
--- a/Scripts/datahandling/zonedata.py
+++ b/Scripts/datahandling/zonedata.py
@@ -90,6 +90,8 @@ class ZoneData:
         self.share["share_detached_houses"] = landdata["detach"]
         self["cbd"] = pandas.Series(0, self.zone_numbers)
         self["cbd"].loc[:param.areas["helsinki_cbd"][1]] = 1
+        self["helsinki_other"] = pandas.Series(0, self.zone_numbers)
+        self["helsinki_other"].loc[:param.areas["helsinki_other"][1]] = 1
         self["helsinki"] = pandas.Series(0, self.zone_numbers)
         self["helsinki"].loc[:param.municipality["Helsinki"][1]] = 1
         self["espoo_vant_kau"] = pandas.Series(0, self.zone_numbers)

--- a/Scripts/datahandling/zonedata.py
+++ b/Scripts/datahandling/zonedata.py
@@ -89,15 +89,15 @@ class ZoneData:
         self["zone_area"] = landdata["builtar"]
         self.share["share_detached_houses"] = landdata["detach"]
         self["cbd"] = pandas.Series(0, self.zone_numbers)
-        self["cbd"].loc[:param.areas["helsinki_cbd"][1]] = 1
+        self["cbd"].loc[param.areas["helsinki_cbd"][0]:param.areas["helsinki_cbd"][1]] = 1
         self["helsinki_other"] = pandas.Series(0, self.zone_numbers)
-        self["helsinki_other"].loc[:param.areas["helsinki_other"][1]] = 1
+        self["helsinki_other"].loc[param.areas["helsinki_other"][0]:param.areas["helsinki_other"][1]] = 1
         self["helsinki"] = pandas.Series(0, self.zone_numbers)
-        self["helsinki"].loc[:param.municipality["Helsinki"][1]] = 1
+        self["helsinki"].loc[param.municipality["Helsinki"][0]:param.municipality["Helsinki"][1]] = 1
         self["espoo_vant_kau"] = pandas.Series(0, self.zone_numbers)
-        self["espoo_vant_kau"].loc[:param.areas["espoo_vant_kau"][1]] = 1
+        self["espoo_vant_kau"].loc[param.areas["espoo_vant_kau"][0]:param.areas["espoo_vant_kau"][1]] = 1
         self["surrounding"] = pandas.Series(0, self.zone_numbers)
-        self["surrounding"].loc[:param.areas["surrounding"][1]] = 1
+        self["surrounding"].loc[param.areas["surrounding"][0]:param.areas["surrounding"][1]] = 1
         self["shops_cbd"] = self["cbd"] * self["shops"]
         self["shops_elsewhere"] = (1-self["cbd"]) * self["shops"]
         # Create diagonal matrix with zone area

--- a/Scripts/parameters.py
+++ b/Scripts/parameters.py
@@ -1864,8 +1864,8 @@ mode_choice = {
             "constant": (0.844179295926 * (3.15335645065 - 0.158), 
                          0.844179295926 * (3.09257722177 - 0.415)),
             "generation": {
-                "cbd": 0.3,
-                "helsinki_other": 0.3,
+                "cbd": 0.4,
+                "helsinki_other": 0.1,
                 "espoo_vant_kau": -0.2,
             },
             "attraction": {},
@@ -1916,8 +1916,8 @@ mode_choice = {
             "constant": (0.272803753976 * (13.2817160786 + 0.211),
                          0.272803753976 * (13.2817160786 - 0.693)),
             "generation": {
-                "cbd": 0.0,
-                "helsinki_other": 0.6,
+                "cbd": 0.3,
+                "helsinki_other": 0.3,
                 "espoo_vant_kau": -0.3,
             },
             "attraction": {},
@@ -1966,8 +1966,8 @@ mode_choice = {
         "transit": {
             "constant": (3.10747422821 - 0.159, 3.10747422821 + 0.700),
             "generation": {
-                "cbd": 0.4,
-                "helsinki_other": 0.4,
+                "cbd": 0.5,
+                "helsinki_other": 0.1,
                 "espoo_vant_kau": -0.3,
             },
             "attraction": {},
@@ -2018,8 +2018,8 @@ mode_choice = {
             "constant": (0.539979474415 * (5.13091589060 - 0.134), 
                          0.539979474415 * (4.98462338486 - 0.476)),
             "generation": {
-                "cbd": 0.0,
-                "helsinki_other": 0.4,
+                "cbd": 0.1,
+                "helsinki_other": 0.1,
                 "espoo_vant_kau": -0.3,
             },
             "attraction": {},
@@ -2072,8 +2072,8 @@ mode_choice = {
             "constant": (0.151688898 * (8.71611785 - 0.209), 
                          0.151688898 * (-9.326014274 + 0.711)),
             "generation": {
-                "cbd": 0.3,
-                "helsinki_other": 0.8,
+                "cbd": 0.4,
+                "helsinki_other": 0.1,
                 "espoo_vant_kau": -0.7,
             },
             "attraction": {},
@@ -2125,8 +2125,8 @@ mode_choice = {
             "constant": (.798132431338 * (1.00739274058 + 0.284),
                          .798132431338 * (1.00739274058 - 3.652)),
             "generation": {
-                "cbd": 1.5,
-                "helsinki_other": 0.5,
+                "cbd": 1.0,
+                "helsinki_other": -0.5,
                 "espoo_vant_kau": -1.0,
             },
             "attraction": {},
@@ -2177,8 +2177,8 @@ mode_choice = {
             "constant": (.798132431338 * (1.00739274058 + 0.352),
                          .798132431338 * (1.00739274058 - 1.051)),
             "generation": {
-                "cbd": 0.6,
-                "helsinki_other": 0.0,
+                "cbd": 0.2,
+                "helsinki_other": -0.4,
                 "espoo_vant_kau": -0.4,
             },
             "attraction": {},

--- a/Scripts/parameters.py
+++ b/Scripts/parameters.py
@@ -1119,7 +1119,8 @@ destination_choice = {
         },
         "transit": {
             "attraction": {
-                "cbd": (0.483086068108, 0.483086068108 + 0.1),
+                "cbd": (0.483086068108, 0.483086068108),
+                "helsinki_other": (0.2, 0.2),
             },
             "impedance": {
                 "time": -0.111547282384e-1,
@@ -1188,8 +1189,8 @@ destination_choice = {
         "transit": {
             "attraction": {
                 "own_zone_area_sqrt": -1.40415965463,
-                "cbd": (0.704345842211 + 0.2,
-                        0.704345842211 + 0.5),
+                "cbd": (0.704345842211 + 0.2, 0.704345842211 + 0.2),
+                "helsinki_other": (0.5, 0.2),
             },
             "impedance": {
                 "time": -0.245629127645e-1,
@@ -1324,7 +1325,8 @@ destination_choice = {
         },
         "transit": {
             "attraction": {
-                "cbd": (0.135335656706, 2.62480475297),
+                "cbd": (0.135335656706 - 0.1, 2.62480475297 - 0.1),
+                "helsinki_other": (0.1, 0.1),
             },
             "impedance": {
                 "time": -0.299237931923e-1,

--- a/Scripts/parameters.py
+++ b/Scripts/parameters.py
@@ -1863,7 +1863,11 @@ mode_choice = {
         "transit": {
             "constant": (0.844179295926 * (3.15335645065 - 0.158), 
                          0.844179295926 * (3.09257722177 - 0.415)),
-            "generation": {},
+            "generation": {
+                "cbd": 0.3,
+                "helsinki_other": 0.3,
+                "espoo_vant_kau": -0.2,
+            },
             "attraction": {},
             "impedance": {},
             "log": {
@@ -1911,7 +1915,11 @@ mode_choice = {
         "transit": {
             "constant": (0.272803753976 * (13.2817160786 + 0.211),
                          0.272803753976 * (13.2817160786 - 0.693)),
-            "generation": {},
+            "generation": {
+                "cbd": 0.0,
+                "helsinki_other": 0.6,
+                "espoo_vant_kau": -0.3,
+            },
             "attraction": {},
             "impedance": {},
             "log": {
@@ -1957,7 +1965,11 @@ mode_choice = {
         },
         "transit": {
             "constant": (3.10747422821 - 0.159, 3.10747422821 + 0.700),
-            "generation": {},
+            "generation": {
+                "cbd": 0.4,
+                "helsinki_other": 0.4,
+                "espoo_vant_kau": -0.3,
+            },
             "attraction": {},
             "impedance": {},
             "log": {
@@ -2005,7 +2017,11 @@ mode_choice = {
         "transit": {
             "constant": (0.539979474415 * (5.13091589060 - 0.134), 
                          0.539979474415 * (4.98462338486 - 0.476)),
-            "generation": {},
+            "generation": {
+                "cbd": 0.0,
+                "helsinki_other": 0.4,
+                "espoo_vant_kau": -0.3,
+            },
             "attraction": {},
             "impedance": {},
             "log": {
@@ -2055,7 +2071,11 @@ mode_choice = {
         "transit": {
             "constant": (0.151688898 * (8.71611785 - 0.209), 
                          0.151688898 * (-9.326014274 + 0.711)),
-            "generation": {},
+            "generation": {
+                "cbd": 0.3,
+                "helsinki_other": 0.8,
+                "espoo_vant_kau": -0.7,
+            },
             "attraction": {},
             "impedance": {},
             "log": {
@@ -2104,7 +2124,11 @@ mode_choice = {
         "transit": {
             "constant": (.798132431338 * (1.00739274058 + 0.284),
                          .798132431338 * (1.00739274058 - 3.652)),
-            "generation": {},
+            "generation": {
+                "cbd": 1.5,
+                "helsinki_other": 0.5,
+                "espoo_vant_kau": -1.0,
+            },
             "attraction": {},
             "impedance": {},
             "log": {
@@ -2152,7 +2176,11 @@ mode_choice = {
         "transit": {
             "constant": (.798132431338 * (1.00739274058 + 0.352),
                          .798132431338 * (1.00739274058 - 1.051)),
-            "generation": {},
+            "generation": {
+                "cbd": 0.6,
+                "helsinki_other": 0.0,
+                "espoo_vant_kau": -0.4,
+            },
             "attraction": {},
             "impedance": {},
             "log": {

--- a/Scripts/tests/integration/test_models.py
+++ b/Scripts/tests/integration/test_models.py
@@ -37,7 +37,7 @@ class ModelTest(unittest.TestCase):
         self._validate_impedances(impedance["iht"])
 
         # Check that model result does not change
-        self.assertAlmostEquals(model.mode_share[0]["car"], 0.62690992825624259)
+        self.assertAlmostEquals(model.mode_share[0]["car"], 0.62926304056428284)
         
         print("Model system test done")
     

--- a/Scripts/tests/integration/test_models.py
+++ b/Scripts/tests/integration/test_models.py
@@ -37,7 +37,7 @@ class ModelTest(unittest.TestCase):
         self._validate_impedances(impedance["iht"])
 
         # Check that model result does not change
-        self.assertAlmostEquals(model.mode_share[0]["car"], 0.69072381507223757)
+        self.assertAlmostEquals(model.mode_share[0]["car"], 0.62690992825624259)
         
         print("Model system test done")
     


### PR DESCRIPTION
* Add transit generation dummy-variables to correct generation of transit trips in different areas (cbd, helsinki_other, espoo_vant_kau).
* Mode share calibration was not included, so mode shares need to be calibrated later. This is done later after new cost estimation.


Calibration file: https://hslfi.sharepoint.com/:x:/r/sites/ext-helmet_kehi_40/Jaetut%20asiakirjat/6%20Analyysit/Kalibrointi/Vertailut/calibration_transit_dummy_dest_v01.xlsx?d=w9075b6758179418fac1686562898108e&csf=1&web=1&e=S8mHkg