### PR TITLE
Update 4verkkoa_HM40.mac

### DIFF
--- a/Database/4verkkoa_HM40.mac
+++ b/Database/4verkkoa_HM40.mac
@@ -157,7 +157,7 @@ reports=
  1
  y
  q
-~< extra_attr.mac
+~# *** must be done when creating a new Emme project ~< extra_attr.mac
 ~#
 ~# ** maaritellaan pysahtymiset
 ~! copy %2%\hsl_kunnat_%1%.mac  hsl_kunnat.mac

--- a/Database/aja_extra_attr_HM31.mac
+++ b/Database/aja_extra_attr_HM31.mac
@@ -1,0 +1,19 @@
+~# *** aja_extra_attr_HM31.mac
+~#
+~# Makro tekee HELMET 3.1:n tarvitsemat extra-attribuutit ajamalla ne luovat makrot
+~# Extra-attribuutit luodaan skenaarioihin 19 ja 21-23
+~# WSP/ARa 3.6.2014, HSL/TE 18.2.2019
+~#
+s=21
+~<extra_attr.mac
+~#
+s=22
+~<extra_attr.mac
+~#
+s=23
+~<extra_attr.mac
+~#
+s=19
+~<extra_attr_pyora.mac
+~#
+~/ kaikki makrot extra_attr_HM31.mac ajettu


### PR DESCRIPTION
Creating extra attributes must be done when creating new Emme scenarios in the Emme project. When created once new values can be read or modified as many times as needed. If the extra attributes exist already recreating them causes an error message. So the line is modified to a comment.