### PR TITLE
Update 4verkkoa_HM40.mac

### DIFF
--- a/Database/4verkkoa_HM40.mac
+++ b/Database/4verkkoa_HM40.mac
@@ -65,11 +65,11 @@ reports=
  2
  off=11
 ~# tyhjenna ja lue pyoraverkon extra attribuutit
- 2.42
- 1
- y
- q
-~< extra_attr_pyora.mac
+~#  2.42
+~#  1
+~#  y
+~#  q
+~# ~< extra_attr_pyora.mac
 ~# ** luetaan pyoratieluokat (makro poistaa tiedoston d241.in 
 ~# ** ja lukee tiedot parametrina annettavasta tiedostosta)
 ~< pyoratieluokat_lue.mac %3% %2%\d241_pyoratieluokka_%1%.in
@@ -151,13 +151,15 @@ reports=
  2.21
 ~?q=2
  2
+~#  2.42
+~#  1
+~#  y
+~#  q
+~# *** tama on parempi tehda skenaarioihin 19 ja 21-23 jo perustettaessa uutta Emme-projektia
+~# ~< extra_attr.mac
+~#
 ~# ** muutetaan linkkien attribuutit (vdf, ul1, ul2) linkkityypin perusteella
 ~< muuta_linkkien_attribuutit_eikorj.mac
- 2.42
- 1
- y
- q
-~# *** must be done when creating a new Emme project ~< extra_attr.mac
 ~#
 ~# ** maaritellaan pysahtymiset
 ~! copy %2%\hsl_kunnat_%1%.mac  hsl_kunnat.mac


### PR DESCRIPTION
It looks like Atte’s philosophy has been that in all scenarios extra attribute table is first initialized and then the ordinary set of extra attributes needed in the model system is recreated. However, the user may have defined also his/her own extra attributes which are lost when using this method. That’s why in my opinion it’s better to define the extra attributes already when creating a new Emme project. Then the attributes exist, and new values can be read as many times as needed. If the user wants to add or delete his/her own attributes it’s possible.

If the user still wants to define the extra attributes in macro 4verkkoa_M2019.mac it must be done before calling the macro muuta_linkkien_attribuutit_eikorj.mac.

In comparison to the nodes, links and transit lines tables, there is no need to do partial modifications. It’s better to initialize the tables and reread the complete nodes, links and transit lines data.