### PR TITLE
Remove zone number check for fixed transit cost matrix

### DIFF
--- a/Scripts/modelsystem.py
+++ b/Scripts/modelsystem.py
@@ -169,7 +169,7 @@ class ModelSystem:
             peripheral_cost = numpy.array(peripheral_mtx._file["transit"])
         if use_fixed_transit_cost:
             log.info("Using fixed transit cost matrix")
-            with self.resultmatrices.open("cost", "aht", self.ass_model.zone_numbers) as aht_mtx:
+            with self.resultmatrices.open("cost", "aht") as aht_mtx:
                 fixed_cost = aht_mtx["transit_work"]
         else:
             log.info("Calculating transit cost")


### PR DESCRIPTION
The check would crash because the file does not contain the same matrices as base data.

Fixes #239.