### PR TITLE
Add fixed transit cost to emme matrices for all time periods

### DIFF
--- a/Scripts/assignment/emme_assignment.py
+++ b/Scripts/assignment/emme_assignment.py
@@ -513,9 +513,10 @@ class EmmeAssignmentModel(AssignmentModel):
         tp = "aht"
         if default_cost is not None:
             # Use fixed cost matrix
-            for transit_class in param.transit_classes:
-                idx = self.result_mtx[tp]["cost"][transit_class]["id"]
-                emmebank.matrix(idx).set_numpy_data(default_cost)
+            for tp in self.time_periods:
+                for transit_class in param.transit_classes:
+                    idx = self.result_mtx[tp]["cost"][transit_class]["id"]
+                    emmebank.matrix(idx).set_numpy_data(default_cost)
             return
 
         scen_id = self.emme_scenarios[tp]


### PR DESCRIPTION
#238 did not take into consideration fixed transit cost matrices. They need to be stored for all time periods in Emme so that the right costs are used in demand calculations.