### PR TITLE
new versions of input macros

### DIFF
--- a/Database/4verkkoa_HM40.mac
+++ b/Database/4verkkoa_HM40.mac
@@ -11,28 +11,87 @@
 ~#     - kaantymiset
 ~#     - seka linkkien ruuhkamaksut (e/km)
 ~#
-~#  parametrit p1 = vaihtoehdon tunnus (esim. 2030_20170329)
+~#  parametrit p1 = tiedostojen nimissa oleva versiotunnus (esim. 2030_ve0_20190329)
 ~#             p2 = alikansio, josta tiedostot luetaan (nykyinen, jos puuttuu)
-~#             p3 pyöräverkon skenaario
-~#             p4 vuorokausiverkko
-~#             p5 aht skenaarion numero
-~#             p6 pt skenaarion numero
-~#             p7 iht skenaarion numero
-~#             p8 skenaarion nimi
+~#             p3 = pyoraverkon skenaarion numero
+~#             p4 = vuorokausiskenaarion numero
+~#             p5 = aht-skenaarion numero
+~#             p6 = pt-skenaarion numero
+~#             p7 = iht-skenaarion numero
+~#             p8 = skenaarioiden nimiin tuleva tunnus
 ~#
 ~#  ajo esim
-~#  ~<4verkkoa_HM40.mac 2016_20191014 sijopankki2016 19 20 21 22 23
-~#  ~<4verkkoa_HM40.mac 2018_20191014 sijopankki2018 29 30 31 32 33
-~#  ~<4verkkoa_HM40.mac 2019_20191122 sijopankki2019 39 40 41 42 43
+~#  ~<4verkkoa_HM40.mac 2016_20191014 sijopankki2016 19 20 21 22 23 V2016
+~#  ~<4verkkoa_HM40.mac 2018_20191014 sijopankki2018 29 30 31 32 33 V2018
+~#  ~<4verkkoa_HM40.mac 2019_20191122 sijopankki2019 39 40 41 42 43 V2019
+~#
+~#  muutokset (TE 3.12.2020)
+~#     Jos kutsussa ei anneta parametreja, ne kysytaan alussa interaktiivisesti.
+~#     Lisatty tarkistusmakron kutsuja
+~#     VRK-skenaariolle ei ajeta eriseen f-makroja, vaan se kopioidaan PT-skenaariosta
+~#  
+~# *** KYSYTAAN KUTSUSTA PUUTTUVAT PARAMETRIT   
+~t1=%1%
+~?t1=
+~t1=~*Mika on tiedostojen nimissa oleva versiotunnus (esim. 2030_ve0_20190329)? 
+~?t1=
+~$ARGU_VIRHE
 ~#     
+~t8=%8%
+~?t8=
+~t8=~*Mika tunnus tulee skenaarioiden nimiin (oletus %t1%)? 
+~?t8=
+~t8=%t1%
+~#
+~t2=%2%
+~?t2=
+~t2=~*Mista alikansiosta tiedostot luetaan (esim. .\sijopankki2030\, oletus nykyinen)? 
+~?t2=
+~t2=.\
+~#
+~t3=%3%
+~?t3=
+~t3=~*Mika on PYORAskenaarion numero (oletus 19)? 
+~?t3=
+~t3=19
+~x=%t3%
+~#
+~x+1
+~t4=%4%
+~?t4=
+~t4=~*Mika on VRK-skenaarion numero (oletus %x%)? 
+~?t4=
+~t4=%x%
+~#
+~x+1
+~t5=%5%
+~?t5=
+~t5=~*Mika on AHT-skenaarion numero (oletus %x%)? 
+~?t5=
+~t5=%x%
+~#
+~x+1
+~t6=%6%
+~?t6=
+~t6=~*Mika on PAIVAskenaarion numero (oletus %x%)? 
+~?t6=
+~t6=%x%
+~#
+~x+1
+~t7=%7%
+~?t7=
+~t7=~*Mika on IHT-skenaarion numero (oletus %x%)? 
+~?t7=
+~t7=%x%
+~#
 batchin=
 reports=
 ~#
 ~# *** PYORAVERKKO
- s=%3%
+ s=%t3%
  1.23
  2
- skenaario %1% pyorailyverkko
+ skenaario %t8% pyorailyverkko
  q
 ~# ** poistetaan vanha sisalto
  2.12
@@ -57,31 +116,32 @@ reports=
  off=11
 ~# ** luetaan verkko
 ~! del  d211.in
-~! copy %2%\d211_verkko_%1%.in  d211.in
-~#** ~! copy %2%\d211_pyoraverkko_%t1%.in  d211.in
+~! copy %t2%\d211_verkko_%t1%.in  d211.in
+~#** ~! copy %t2%\d211_pyoraverkko_%t1%.in  d211.in
  on=11
  2.11
 ~?q=2
  2
  off=11
 ~# tyhjenna ja lue pyoraverkon extra attribuutit
- 2.42
- 1
- y
- q
-~< extra_attr_pyora.mac
+~# TE 13.10.2020 muutettu kommentiksi, koska extra-attribuutit maaritellaan jo projektia perustettaessa
+~# 2.42
+~# 1
+~# y
+~# q
+~# ~< extra_attr_pyora.mac
 ~# ** luetaan pyoratieluokat (makro poistaa tiedoston d241.in 
 ~# ** ja lukee tiedot parametrina annettavasta tiedostosta)
-~< pyoratieluokat_lue.mac %3% %2%\d241_pyoratieluokka_%1%.in
+~< pyoratieluokat_lue.mac %t3% %t2%\d241_pyoratieluokka_%t1%.in
 ~#
 ~# ** vaihdetaan viivytysfunktioiden numerot pyoraverkolle
 ~< vdf_pyora.mac
 ~#
 ~# *** AUTO- JA JKL-VERKKO
- s=%5%
+ s=%t5%
  1.23
  2
- %1% aht
+ %t1% aht
  q
 ~# ** poistetaan vanha sisalto
  2.22
@@ -128,7 +188,7 @@ reports=
  off=11
 ~# ** luetaan verkko
 ~! del  d211.in
-~! copy %2%\d211_verkko_%1%.in  d211.in
+~! copy %t2%\d211_verkko_%t1%.in  d211.in
  on=11
  2.11
 ~?q=2
@@ -136,7 +196,7 @@ reports=
  off=11
 ~# ** luetaan kaantymiset
 ~! del  d231.in
-~! copy %2%\d231_verkko_%1%.in  d231.in 
+~! copy %t2%\d231_verkko_%t1%.in  d231.in 
  on=11
  2.31
  2
@@ -146,21 +206,22 @@ reports=
  off=11
 ~# ** luetaan linjasto
 ~! del  d221.in
-~! copy %2%\d221_linjat_%1%.in  d221.in 
+~! copy %t2%\d221_linjat_%t1%.in  d221.in 
  on=11
  2.21
 ~?q=2
  2
 ~# ** muutetaan linkkien attribuutit (vdf, ul1, ul2) linkkityypin perusteella
 ~< muuta_linkkien_attribuutit_eikorj.mac
- 2.42
- 1
- y
- q
-~< extra_attr.mac
+~# TE 13.10.2020 muutettu kommentiksi, koska extra-attribuutit maaritellaan jo projektia perustettaessa
+~# 2.42
+~# 1
+~# y
+~# q
+~# ~< extra_attr.mac
 ~#
 ~# ** maaritellaan pysahtymiset
-~! copy %2%\hsl_kunnat_%1%.mac  hsl_kunnat.mac
+~! copy %t2%\hsl_kunnat_%t1%.mac  hsl_kunnat.mac
 ~< hsl_kunnat.mac
 ~< pysakki.mac
 ~# ** tarkistetaan extra-attribuutit
@@ -172,85 +233,119 @@ reports=
 ~#
 ~# ** luetaan hinnat (makro poistaa tiedoston d241.in 
 ~# ** ja lukee tiedot parametrina annettavasta tiedostosta)
-~< hinnat_lue.mac %5% %2%\d241_hinta_%1%.in
+~< hinnat_lue.mac %t5% %t2%\d241_hinta_%t1%.in
 ~#
 ~# ** luetaan vuorovalit (makro poistaa tiedoston d241.in 
 ~# ** ja lukee tiedot parametrina annettavasta tiedostosta)
-~< vuorovalit_lue.mac %5% %2%\d241_vuorovalit_%1%.in
+~< vuorovalit_lue.mac %t5% %t2%\d241_vuorovalit_%t1%.in
 ~#
 ~# ** kopioidaan aht-skenaario pt- ja iht-skenaarioiksi
  1.22
  2
- %4%
+ %t6%
  y
 ~#
  3
- %5%
- %4%
-
- n
- 2
- %6%
- y
-~#
- 3
- %5%
- %6%
+ %t5%
+ %t6%
 
  n
 ~#
  2
- %7%
+ %t7%
  y
 ~#
  3
- %5%
- %7%
+ %t5%
+ %t7%
 
  n
  q
+~#
+~t9=4verkkoa_HM40.txt
+~! copy  %t9%  4verkkoa_HM40_old.txt
+~! del   %t9%
+ reports=%t9%
+~! ECHO *** Tarkistuksia muodostettuihin liikennejarjestelmakuvauksiin %t1% *** >> %t9%
+~! date /t >> %t9%
+~! time /t >> %t9%
+ reports=
+~#
  sta
- s=%4%
+ s=%t5%
  1.23
  2
- skenaario %1% vrk
- q
-~< f_bussi_M2016_3p.mac
-~< f_us2_M2016_4p.mac
-~< f_jkl_M2016_5p.mac
-~< vuorovalit_kopioi.mac %6% @hwpt  hdwy
-~< vuorovalit_kopioi.mac %6% @hinpt @hinta
-~#
- s=%5%
- 1.23
- 2
- skenaario %1% aht
+ skenaario %t8% aht
  q
 ~< f_bussi_M2016_3a.mac
 ~< f_us2_M2016_4a.mac
 ~< f_jkl_M2016_5a.mac
-~< vuorovalit_kopioi.mac %5% @hwaht hdwy
-~< vuorovalit_kopioi.mac %5% @hinah @hinta
+~< vuorovalit_kopioi.mac %t5% @hwaht hdwy
+~< vuorovalit_kopioi.mac %t5% @hinah @hinta
+~< tarkista_verkko.mac %t9% AHT
 ~#
- s=%6%
+ s=%t6%
  1.23
  2
- skenaario %1% pt
+ skenaario %t8% pt
  q
 ~< f_bussi_M2016_3p.mac
 ~< f_us2_M2016_4p.mac
 ~< f_jkl_M2016_5p.mac
-~< vuorovalit_kopioi.mac %6% @hwpt  hdwy
-~< vuorovalit_kopioi.mac %6% @hinpt @hinta
+~< vuorovalit_kopioi.mac %t6% @hwpt  hdwy
+~< vuorovalit_kopioi.mac %t6% @hinpt @hinta
+~< tarkista_verkko.mac %t9% PT
 ~#
- s=%7%
+ s=%t7%
  1.23
  2
- skenaario %1% iht
+ skenaario %t8% iht
  q
 ~< f_bussi_M2016_3i.mac
 ~< f_us2_M2016_4i.mac
 ~< f_jkl_M2016_5i.mac
-~< vuorovalit_kopioi.mac %7% @hwiht hdwy
-~< vuorovalit_kopioi.mac %7% @hinih @hinta
-~/ *** Verkot paivitetty
+~< vuorovalit_kopioi.mac %t7% @hwiht hdwy
+~< vuorovalit_kopioi.mac %t7% @hinih @hinta
+~< tarkista_verkko.mac %t9% IHT
+~#
+ s=%t3%
+~< tarkista_verkko.mac %t9% PP
+~#
+~! copy 4verkkoa_HM40.txt  4verkkoa_HM40_%t1%.txt
+~#
+~# ** kopioidaan pt-skenaario vrk-skenaarioksi
+ 1.22
+ 2
+ %t4%
+ y
+~#
+ 3
+ %t6%
+ %t4%
+
+ n
+ q
+~#
+ s=%t4%
+ 1.23
+ 2
+ skenaario %t8% vrk
+ q
+~$LOPPU
+~#
+~:ARGU_VIRHE
+~/ *** Anna argumenttina 
+~/     1) tiedostojen nimissa oleva versiotunnus (esim. 2030_ve0_20190329)
+~/     2) alikansio, josta tiedostot luetaan (esim. .\sijopankki2030\, oletus nykyinen)
+~/     3) pyoraverkon skenaarion numero s (oletus s=19)
+~/     4) vuorokausiskenaarion numero (oletus s+1)
+~/     5) aht-skenaarion numero (oletus s+2)
+~/     6) pt-skenaarion numero  (oletus s+3)
+~/     7) iht-skenaarion numero (oletus s+4)
+~/     8) skenaarioiden nimiin tuleva tunnus (oletus sama kuin 1)
+~#
+~:LOPPU
+
+~/ *** 4verkkoa_HM40_TE.mac %t1% %t2% %t3% %t4% %t5% %t6% %t7% %t8% ajettu ja verkot paivitetty
+~/ *** Tarkistusten tuloksia on tiedostossa %t9%
+

--- a/Database/tarkista_verkko.mac
+++ b/Database/tarkista_verkko.mac
@@ -2,10 +2,13 @@
 ~#
 ~# tehdaan muodostettuihin liikennejarjestelmakuvauksiin joitakin tarkistuksia
 ~# parametri p1 = tulostustiedoston nimi
-~# TE 5.10.2017
+~#           p2 = skenaarion tunnus (vain AHT ja PP merkitysta)
+~# TE 19.11.2020
 ~#
 ~# Muutoksia
 ~#    Lisattu pyoraverkon (s=19) yhteenvedon tulostus (TE 22.1.2019)
+~#    lisatty ratikoiden nopeuden ja junaliikenteen pysahtymisten testaus (19.11.2020)
+~#    Muutettu testeja makron 4verkkoa_HM40.mac mukaisiksi (1.12.2020)
 ~#
 ~t1=%1%
 ~?t1=
@@ -14,6 +17,7 @@
  reports=%t1%
 ~! ECHO * >> %t1%
 ~! ECHO ****** SKENAARION %s% TARKISTUS ALKAA ****** >> %t1%
+~#
 ~! ECHO * >> %t1%
 ~! ECHO *** Yhteenveto linkkityypeista (x01-x14 vai x21-x42) ja viivytysfunktioista *** >> %t1%
  2.14
@@ -34,9 +38,14 @@
  q
 ~#
 ~# ** pyoraverkkoa ei tarkisteta enempaa
-~x=%s%
-~?x=19
+~t2=%2%
+~/ parametrit %t1%  %t2%
+~?t2=PP
 ~$LOPPU
+~#
+~# ** aikajaksojen muut yhteiset ominaisuudet tarkistetaan vain aht-skenaariosta
+~?!t2=AHT
+~$OHI
 ~#
 ~! ECHO * >> %t1%
 ~! ECHO *** Linkilta puuttuu kapasiteetti, jos alla on riveja, joilla ul1=0 *** >> %t1%
@@ -62,6 +71,173 @@
  2
  q
 ~#
+~! ECHO * >> %t1%
+~! ECHO *** Linkilta puuttuu autoliikenteen viivytysfunktio, jos alla on riveja, joilla vdf=0 *** >> %t1%
+ 2.14
+ 2
+ n
+ mod=c
+ and vdf=0
+
+~?q=2
+ 2
+ q
+~#
+~! ECHO * >> %t1%
+~! ECHO *** Linkin ul1-kentassa olevan raitiovaunuliikenteen nopeuden minimi- ja maksimiarvot, AHT *** >> %t1%
+ 2.41
+ 1
+ n
+ int(ul1/10000)
+
+ mod=tp
+
+ 2
+~?q=2
+ 2
+ q
+~#
+~! ECHO * >> %t1%
+~! ECHO *** Linkin ul1-kentassa olevan raitiovaunuliikenteen nopeuden minimi- ja maksimiarvot, PT *** >> %t1%
+ 2.41
+ 1
+ n
+ int(ul1/100) .mod. 100
+
+ mod=tp
+
+ 2
+~?q=2
+ 2
+ q
+~#
+~! ECHO * >> %t1%
+~! ECHO *** Linkin ul1-kentassa olevan raitiovaunuliikenteen nopeuden minimi- ja maksimiarvot, IHT *** >> %t1%
+ 2.41
+ 1
+ n
+ ul1 .mod. 100
+
+ mod=tp
+
+ 2
+~?q=2
+ 2
+ q
+~#
+~! ECHO * >> %t1%
+~! ECHO *** Linkin ul1-kentassa olevan raitiovaunuliikenteen nopeus on nolla ainakin yhdella aikajaksolla *** >> %t1%
+~! ECHO *** jos alla on muitakin kuin tyhjia riveja. Tarkista linkin koodaus, jos aa=0 tai pp=0 tai ii=0, kun ul1=aappii ** >> %t1%
+ 2.41
+ 1
+ y
+ @lvari
+ n
+ (int(ul1/10000).eq.0) + ((int(ul1/100) .mod. 100).eq.0) + 
+ ((ul1 .mod. 100).eq.0)
+
+ mod=tp
+
+ 4
+ q
+~#
+ 2.14
+ 2
+ n
+ mod=tp
+ and not @lvari=0
+
+~?q=2
+ 2
+ q
+~#
+~! ECHO * >> %t1%
+~! ECHO *** Juna- tai metroliikenteen matka-aika us1=0 ennen pysahtymista (noalin=0 tai noboan=0), jos rivin "line inode jnode..." ** >> %t1%
+~! ECHO *** alla on muitakin kuin tyhjia riveja. Tarkista reitin koodaus, jos rivilla @ccost=1 ** >> %t1%
+ 2.41
+ 1
+ y
+ @ccost
+ n
+ (us1.eq.0).and.((noalin.eq.0).or.(noboan.eq.0))
+
+ mod=mr
+
+ mod=mr
+
+ 4
+~#
+ 1
+ y
+ @lvari
+ n
+ @ccost
+
+ 2
+ mod=mr
+
+ mod=mr
+
+ 4
+~#
+ 1
+ n
+ us1+noalin+noboan+@ccost
+
+ 2
+ mod=mr
+
+ not @lvari=0
+
+ 1
+~?q=2
+ 2
+ q
+~#
+~! ECHO * >> %t1%
+~! ECHO *** Juna- tai metroliikenteen matka-aika us1 poikkeaa nollasta, vaikka ei pysahdysta (noalin=1 ja noboan=1), jos rivin "line inode jnode..." ** >> %t1%
+~! ECHO *** alla on muitakin kuin tyhjia riveja. Tarkista reitin koodaus, jos rivilla @ccost=1 ** >> %t1%
+ 2.41
+ 1
+ y
+ @ccost
+ n
+ (us1.ne.0).and.((noalin.eq.1).and.(noboan.eq.1))
+
+ mod=mr
+
+ mod=mr
+
+ 4
+~#
+ 1
+ y
+ @lvari
+ n
+ @ccost
+
+ 2
+ mod=mr
+
+ mod=mr
+
+ 4
+~#
+ 1
+ n
+ us1+noalin+noboan+@ccost
+
+ 2
+ mod=mr
+
+ not @lvari=0
+
+ 1
+~?q=2
+ 2
+ q
+~#
+~:OHI
 ~! ECHO * >> %t1%
 ~! ECHO *** Linjalta puuttuu vuorovali, jos alla on riveja, joilla hdwy=0.01 *** >> %t1%
  2.24


### PR DESCRIPTION
Improved version of 4verkkoa_HM40.mac. If all arguments are not in the macro call the values for missing arguments is asked interactively. Only the identifier used in the input file names is mandatory, otherwise default values can be used. Added calls of tarkista_verkko.mac, which outputs summaries and makes some preliminary tests of attribute values (e.q. zeros in link lengths, transit line headways or tram speeds).

The arguments used in the call of macro 4verkkoa_HM40.mac are:
1) identifier in the input file names (e.g. 2030_ve0_20190329), mandatory
2) folder where input files are located (e.g. .\sijopankki2030\, current folder as a default)
3) number of bike scenario s (default s=19)
4) number of 24h (vrk) scenario (default s+1)
5) number of morning peak (aht) scenario (default s+2)
6) number of daytime (pt) scenario (default s+3)
7) number of evening peak (iht) scenario (default s+4)
8) identifier used in scenario names (default equals argument 1)