### PR TITLE
Fix bugs in network import

### DIFF
--- a/Database/4verkkoa_HM40.mac
+++ b/Database/4verkkoa_HM40.mac
@@ -346,7 +346,5 @@ reports=
 ~#
 ~:LOPPU
 
-~/ *** 4verkkoa_HM40_TE.mac %t1% %t2% %t3% %t4% %t5% %t6% %t7% %t8% ajettu ja verkot paivitetty
+~/ *** 4verkkoa_HM40.mac %t1% %t2% %t3% %t4% %t5% %t6% %t7% %t8% ajettu ja verkot paivitetty
 ~/ *** Tarkistusten tuloksia on tiedostossa %t9%
-
->>>>>>> 9b3abc3... new versions of input macros

--- a/Database/tee_vuorovalimuuttujat.mac
+++ b/Database/tee_vuorovalimuuttujat.mac
@@ -35,4 +35,10 @@
  ajoaika
  0
 ~#
+ 2
+ 4 \segmenttimuuttuja
+ @ccost
+ congestion cost
+ 0
+~#
  q


### PR DESCRIPTION
The additions to input macros in #251 uses `@ccost` as a temp variable, but this attribute was not added in the macros (it is created in the model run).  I also messed up the merge a little bit, so this is fixed now.