### PR TITLE
Agent model results

### DIFF
--- a/Scripts/datahandling/resultdata.py
+++ b/Scripts/datahandling/resultdata.py
@@ -15,17 +15,15 @@ class ResultsData:
         if not os.path.exists(results_directory_path):
             os.makedirs(results_directory_path)
         self.path = results_directory_path
-        self._list_buffer = {}
+        self._line_buffer = {}
         self._df_buffer = {}
         self._xlsx_buffer = {}
 
     def flush(self):
         """Save to files and empty buffers."""
-        for filename in self._list_buffer:
-            with open(os.path.join(self.path, "{}.txt".format(filename)), 'w') as f:
-                for row in self._list_buffer[filename]:
-                    f.write(row)
-        self._list_buffer = {}
+        for filename in self._line_buffer:
+            self._line_buffer[filename].close()
+        self._line_buffer = {}
         for filename in self._df_buffer:
             self._df_buffer[filename].to_csv(
                 os.path.join(self.path, filename),
@@ -55,6 +53,21 @@ class ResultsData:
             self._df_buffer[filename] = df.reindex(
                 df.index.union(data.index), copy=False)
             self._df_buffer[filename][colname] = data
+
+    def print_line(self, line, filename):
+        """Write text to line in file (closed when flushing).
+
+        Parameters
+        ----------
+        line : str
+            Row of text
+        filename : str
+            Name of file where text is pushed (can contain other text)
+        """
+        if filename not in self._line_buffer:
+            self._line_buffer[filename] = open(
+                os.path.join(self.path, "{}.txt".format(filename)), 'w')
+        self._line_buffer[filename].write(line + "\n")
 
     def print_matrix(self, data, filename, sheetname):
         """Save 2-d matrix data to buffer (printed to file when flushing).
@@ -90,11 +103,10 @@ class ResultsData:
                 ws.cell(row=i+2, column=1).value = data.index[i]
                 for j in xrange(0, data.shape[1]):
                     ws.cell(row=i+2, column=j+2).value = data.iloc[i, j]
-        # Create list file
-        if filename not in self._list_buffer:
-            self._list_buffer[filename] = []
+        # Create text file
         sheetname = sheetname.replace("_", "\t")
         for j in data.columns:
             for i in data.index:
-                self._list_buffer[filename].append(
-                    "{}\t{}\t{}\t{}\n".format(i, j, sheetname, str(data[j][i])))
+                self.print_line(
+                    "{}\t{}\t{}\t{}".format(i, j, sheetname, str(data[j][i])),
+                    filename)

--- a/Scripts/datahandling/zonedata.py
+++ b/Scripts/datahandling/zonedata.py
@@ -5,6 +5,7 @@ import parameters.zone as param
 from utils.read_csv_file import read_csv_file
 from utils.zone_interval import ZoneIntervals, zone_interval
 import utils.log as log
+from datatypes.zone import Zone
 
 
 class ZoneData:
@@ -17,8 +18,8 @@ class ZoneData:
         external = param.areas["external"]
         first_extra = numpy.searchsorted(zone_numbers, peripheral[1], "right")
         self.zone_numbers = zone_numbers[:first_extra]
-        self.mapping = {self.zone_numbers[i]: i
-            for i in xrange(self.zone_numbers.size)}
+        Zone.counter = 0
+        self.zones = {number: Zone(number) for number in self.zone_numbers}
         first_surrounding = numpy.searchsorted(self.zone_numbers, surrounding[0])
         self.first_surrounding_zone = first_surrounding
         first_peripheral = numpy.searchsorted(self.zone_numbers, peripheral[0])
@@ -172,7 +173,7 @@ class ZoneData:
         int
             Index of zone number
         """
-        return self.mapping[zone_number]
+        return self.zones[zone_number].index
 
     def get_freight_data(self):
         """Get zone data for freight traffic calculation.

--- a/Scripts/datatypes/person.py
+++ b/Scripts/datatypes/person.py
@@ -140,7 +140,7 @@ class Person:
             sustainable_access += tour.sustainable_accessibility
             car_access += tour.car_accessibility
         # print to file
-        persondata = "{:d}\t{:s}\t{:s}\t{!s}\t".format(
+        persondata = "{:d}\t{:s}\t{:s}\t{!s}\t{:.0f}".format(
             self.id, self.age_group, self.gender, self.is_car_user, self.income)
         zonedata = "{:d}\t{:s}\t{:s}".format(
             self.zone.number, self.zone.area, self.zone.municipality)

--- a/Scripts/datatypes/person.py
+++ b/Scripts/datatypes/person.py
@@ -36,9 +36,6 @@ class Person:
         self._im = income_model
         self._car_use_draw = random.random()
         self._tour_combination_draw = random.random()
-        self.total_access = 0
-        self.sustainable_access = 0
-        self.car_access = 0
 
     def decide_car_use(self):
         car_use_prob = self._cm.calc_individual_prob(
@@ -121,3 +118,31 @@ class Person:
                 if random.random() < non_home_prob:
                     non_home_tour = Tour(purposes["oo"], tour)
                     self.tours.append(non_home_tour)
+
+    def write_file(self, resultdata, filename):
+        """ Write person data to file.
+
+        Parameters
+        ----------
+        resultdata : ResultData
+            Writer object to result directory
+        """
+        # sum accessibility of all tours
+        nr_tours = 0
+        total_access = 0
+        sustainable_access = 0
+        car_access = 0
+        for tour in self.tours:
+            nr_tours += 1
+            total_access += tour.total_accessibility
+            sustainable_access += tour.sustainable_accessibility
+            car_access += tour.car_accessibility
+        # print to file
+        persondata = "{:s}\t{:s}\t{!s}\t".format(
+            self.age_group, self.gender, self.is_car_user, self.income)
+        zonedata = "{:d}\t{:s}\t{:s}".format(
+            self.zone.number, self.zone.area, self.zone.municipality)
+        accessdata = "{:d}\t{:.1f}\t{:.1f}\t{:.1f}".format(
+            nr_tours, total_access, sustainable_access, car_access)
+        resultdata.print_line("\t".join(
+            [persondata, zonedata, accessdata]), filename)

--- a/Scripts/datatypes/person.py
+++ b/Scripts/datatypes/person.py
@@ -132,12 +132,10 @@ class Person:
             Writer object to result directory
         """
         # sum accessibility of all tours
-        nr_tours = 0
         total_access = 0
         sustainable_access = 0
         car_access = 0
         for tour in self.tours:
-            nr_tours += 1
             total_access += tour.total_accessibility
             sustainable_access += tour.sustainable_accessibility
             car_access += tour.car_accessibility
@@ -147,6 +145,6 @@ class Person:
         zonedata = "{:d}\t{:s}\t{:s}".format(
             self.zone.number, self.zone.area, self.zone.municipality)
         accessdata = "{:d}\t{:.1f}\t{:.1f}\t{:.1f}".format(
-            nr_tours, total_access, sustainable_access, car_access)
+            len(self.tours), total_access, sustainable_access, car_access)
         resultdata.print_line("\t".join(
             [persondata, zonedata, accessdata]), filename)

--- a/Scripts/datatypes/person.py
+++ b/Scripts/datatypes/person.py
@@ -25,7 +25,9 @@ class Person:
     FEMALE = 0
     MALE = 1
     
-    def __init__(self, zone, age_group, generation_model, car_use_model, income_model):
+    def __init__(self, person_id, zone, age_group, 
+                 generation_model, car_use_model, income_model):
+        self.id = person_id
         self.zone = zone
         self.age = random.randint(age_group[0], age_group[1])
         self.age_group = "age_" + str(age_group[0]) + "-" + str(age_group[1])
@@ -138,8 +140,8 @@ class Person:
             sustainable_access += tour.sustainable_accessibility
             car_access += tour.car_accessibility
         # print to file
-        persondata = "{:s}\t{:s}\t{!s}\t".format(
-            self.age_group, self.gender, self.is_car_user, self.income)
+        persondata = "{:d}\t{:s}\t{:s}\t{!s}\t".format(
+            self.id, self.age_group, self.gender, self.is_car_user, self.income)
         zonedata = "{:d}\t{:s}\t{:s}".format(
             self.zone.number, self.zone.area, self.zone.municipality)
         accessdata = "{:d}\t{:.1f}\t{:.1f}\t{:.1f}".format(

--- a/Scripts/datatypes/person.py
+++ b/Scripts/datatypes/person.py
@@ -25,6 +25,10 @@ class Person:
     ID = 0
     FEMALE = 0
     MALE = 1
+    person_attr = ["id", "age_group", "gender", "is_car_user", "income", "nr_tours"]
+    zone_attr =  ["number", "area", "municipality"]
+    tour_attr = ["total_access", "sustainable_access", "car_access"]
+    attr = person_attr + zone_attr + tour_attr
     
     def __init__(self, zone, age_group, 
                  generation_model, car_use_model, income_model):
@@ -122,29 +126,23 @@ class Person:
                 if random.random() < non_home_prob:
                     non_home_tour = Tour(purposes["oo"], tour)
                     self.tours.append(non_home_tour)
+        self.nr_tours = len(self.tours)
 
-    def write_file(self, resultdata, filename):
-        """ Write person data to file.
+    def __str__(self):
+        """ Return person attributes as string.
 
-        Parameters
+        Returns
         ----------
-        resultdata : ResultData
-            Writer object to result directory
+        str
+            Person object attributes.
         """
         # sum accessibility of all tours
-        total_access = 0
-        sustainable_access = 0
-        car_access = 0
+        tour_attributes = dict.fromkeys(Person.tour_attr, 0)
         for tour in self.tours:
-            total_access += tour.total_accessibility
-            sustainable_access += tour.sustainable_accessibility
-            car_access += tour.car_accessibility
+            for attr in tour_attributes:
+                tour_attributes[attr] += getattr(tour, attr)
         # print to file
-        persondata = "{:d}\t{:s}\t{:s}\t{!s}\t{:.0f}".format(
-            self.id, self.age_group, self.gender, self.is_car_user, self.income)
-        zonedata = "{:d}\t{:s}\t{:s}".format(
-            self.zone.number, self.zone.area, self.zone.municipality)
-        accessdata = "{:d}\t{:.1f}\t{:.1f}\t{:.1f}".format(
-            len(self.tours), total_access, sustainable_access, car_access)
-        resultdata.print_line("\t".join(
-            [persondata, zonedata, accessdata]), filename)
+        persondata = [str(getattr(self, attr)) for attr in Person.person_attr]
+        zonedata = [str(getattr(self.zone, attr)) for attr in Person.zone_attr]
+        tourdata = [str(tour_attributes[attr]) for attr in tour_attributes]
+        return "\t".join(persondata + zonedata + tourdata)

--- a/Scripts/datatypes/person.py
+++ b/Scripts/datatypes/person.py
@@ -22,12 +22,14 @@ class Person:
         Model used to decide if car user
     """
 
+    ID = 0
     FEMALE = 0
     MALE = 1
     
-    def __init__(self, person_id, zone, age_group, 
+    def __init__(self, zone, age_group, 
                  generation_model, car_use_model, income_model):
-        self.id = person_id
+        self.id = Person.ID
+        Person.ID += 1
         self.zone = zone
         self.age = random.randint(age_group[0], age_group[1])
         self.age_group = "age_" + str(age_group[0]) + "-" + str(age_group[1])

--- a/Scripts/datatypes/person.py
+++ b/Scripts/datatypes/person.py
@@ -22,7 +22,7 @@ class Person:
         Model used to decide if car user
     """
 
-    ID = 0
+    id_counter = 0
     FEMALE = 0
     MALE = 1
     person_attr = ["id", "age_group", "gender", "is_car_user", "income", "nr_tours"]
@@ -32,8 +32,8 @@ class Person:
     
     def __init__(self, zone, age_group, 
                  generation_model, car_use_model, income_model):
-        self.id = Person.ID
-        Person.ID += 1
+        self.id = Person.id_counter
+        Person.id_counter += 1
         self.zone = zone
         self.age = random.randint(age_group[0], age_group[1])
         self.age_group = "age_" + str(age_group[0]) + "-" + str(age_group[1])

--- a/Scripts/datatypes/person.py
+++ b/Scripts/datatypes/person.py
@@ -144,5 +144,5 @@ class Person:
         # print to file
         persondata = [str(getattr(self, attr)) for attr in Person.person_attr]
         zonedata = [str(getattr(self.zone, attr)) for attr in Person.zone_attr]
-        tourdata = [str(tour_attributes[attr]) for attr in tour_attributes]
+        tourdata = [str(tour_attributes[attr]) for attr in Person.tour_attr]
         return "\t".join(persondata + zonedata + tourdata)

--- a/Scripts/datatypes/person.py
+++ b/Scripts/datatypes/person.py
@@ -11,8 +11,8 @@ class Person:
     
     Parameters
     ----------
-    zone : int
-        Zone number, where person resides
+    zone : datatypes.zone.Zone
+        Zone where person resides
     age_group : tuple
         int
             Age interval to which the person belongs
@@ -39,14 +39,14 @@ class Person:
 
     def decide_car_use(self):
         car_use_prob = self._cm.calc_individual_prob(
-            self.age_group, self.gender, self.zone)
+            self.age_group, self.gender, self.zone.number)
         self.is_car_user = self._car_use_draw < car_use_prob
 
     def calc_income(self):
         if self.age < 17:
             self.income = 0
         else:
-            log_income = self._im.log_income[self.zone]
+            log_income = self._im.log_income[self.zone.number]
             if self.is_car_user:
                 log_income += param["car_users"]
             if self.gender in param:
@@ -83,9 +83,8 @@ class Person:
                     Matrix with cumulative tour combination probabilities
                     for all zones
         """
-        zone_idx = self.generation_model.zone_data.zone_index(self.zone)
         tour_comb_idx = numpy.searchsorted(
-            tour_probs[self.age_group][self.is_car_user][zone_idx, :],
+            tour_probs[self.age_group][self.is_car_user][self.zone.index, :],
             self._tour_combination_draw)
         new_tours = list(self.generation_model.tour_combinations[tour_comb_idx])
         old_tours = self.tours

--- a/Scripts/datatypes/person.py
+++ b/Scripts/datatypes/person.py
@@ -27,7 +27,7 @@ class Person:
     MALE = 1
     person_attr = ["id", "age_group", "gender", "is_car_user", "income", "nr_tours"]
     zone_attr =  ["number", "area", "municipality"]
-    tour_attr = ["total_access", "sustainable_access", "car_access"]
+    tour_attr = ["total_access", "sustainable_access"]
     attr = person_attr + zone_attr + tour_attr
     
     def __init__(self, zone, age_group, 

--- a/Scripts/datatypes/person.py
+++ b/Scripts/datatypes/person.py
@@ -36,6 +36,9 @@ class Person:
         self._im = income_model
         self._car_use_draw = random.random()
         self._tour_combination_draw = random.random()
+        self.total_access = 0
+        self.sustainable_access = 0
+        self.car_access = 0
 
     def decide_car_use(self):
         car_use_prob = self._cm.calc_individual_prob(

--- a/Scripts/datatypes/tour.py
+++ b/Scripts/datatypes/tour.py
@@ -115,11 +115,13 @@ class Tour(object):
         is_car_user : bool
             Whether the person is car user or not
         """
-        self._mode_idx = numpy.searchsorted(
-            self.purpose.model.calc_individual_mode_prob(
-                is_car_user, self.position[0]).cumsum(),
-            self._mode_draw)
+        probs, total, sust, car = self.purpose.model.calc_individual_mode_prob(
+                is_car_user, self.position[0])
+        self._mode_idx = numpy.searchsorted(probs.cumsum(), self._mode_draw)
         self.purpose.generated_tours[self.mode][self.position[0]] += 1
+        self.total_accessibility = total
+        self.sustainable_accessibility = sust
+        self.car_accessibility = car
 
     def choose_destination(self, sec_dest_tours):
         """Choose primary destination for the tour.

--- a/Scripts/datatypes/tour.py
+++ b/Scripts/datatypes/tour.py
@@ -118,9 +118,9 @@ class Tour(object):
                 is_car_user, self.position[0])
         self._mode_idx = numpy.searchsorted(probs.cumsum(), self._mode_draw)
         self.purpose.generated_tours[self.mode][self.position[0]] += 1
-        self.total_accessibility = total
-        self.sustainable_accessibility = sust
-        self.car_accessibility = car
+        self.total_access = total
+        self.sustainable_access = sust
+        self.car_access = car
 
     def choose_destination(self, sec_dest_tours):
         """Choose primary destination for the tour.

--- a/Scripts/datatypes/tour.py
+++ b/Scripts/datatypes/tour.py
@@ -99,10 +99,9 @@ class Tour(object):
 
     @position.setter
     def position(self, position):
-        try:
-            _ = self._position[0]
+        if hasattr(self, "_position"):
             self._position = position
-        except AttributeError:
+        else:
             self._non_home_position = position[1:]
 
     def choose_mode(self, is_car_user):

--- a/Scripts/datatypes/tour.py
+++ b/Scripts/datatypes/tour.py
@@ -12,7 +12,7 @@ class Tour(object):
     ----------
     purpose : datatypes.purpose.TourPurpose
         Travel purpose (hw/hs/ho/...)
-    origin : int or Tour
+    origin : Zone or Tour
         Origin zone number or origin tour (if non-home tour)
     """
     # Expansion factor used on demand in departure time model
@@ -48,8 +48,8 @@ class Tour(object):
     @orig.setter
     def orig(self, origin):
         try:
-            self._position = (self.purpose.zone_data.zone_index(origin),)
-        except KeyError:
+            self._position = (origin.index,)
+        except AttributeError:
             # If this is non-home tour, origin refers to home-based tour
             self._source = origin
             self._non_home_position = ()
@@ -65,7 +65,7 @@ class Tour(object):
     def dest(self, destination):
         self.position = (
             self.position[0],
-            self.purpose.zone_data.zone_index(destination)
+            destination.index
         )
 
     @property
@@ -80,7 +80,7 @@ class Tour(object):
         self.position = (
             self.position[0],
             self.position[1],
-            self.purpose.zone_data.zone_index(destination)
+            destination.index
         )
 
     @property
@@ -99,9 +99,10 @@ class Tour(object):
 
     @position.setter
     def position(self, position):
-        if hasattr(self, "_position"):
+        try:
+            _ = self._position[0]
             self._position = position
-        else:
+        except AttributeError:
             self._non_home_position = position[1:]
 
     def choose_mode(self, is_car_user):

--- a/Scripts/datatypes/tour.py
+++ b/Scripts/datatypes/tour.py
@@ -114,13 +114,12 @@ class Tour(object):
         is_car_user : bool
             Whether the person is car user or not
         """
-        probs, total, sust, car = self.purpose.model.calc_individual_mode_prob(
+        probs, total, sust = self.purpose.model.calc_individual_mode_prob(
                 is_car_user, self.position[0])
         self._mode_idx = numpy.searchsorted(probs.cumsum(), self._mode_draw)
         self.purpose.generated_tours[self.mode][self.position[0]] += 1
         self.total_access = total
         self.sustainable_access = sust
-        self.car_access = car
 
     def choose_destination(self, sec_dest_tours):
         """Choose primary destination for the tour.

--- a/Scripts/datatypes/zone.py
+++ b/Scripts/datatypes/zone.py
@@ -1,4 +1,5 @@
 from parameters.zone import areas, municipalities
+from utils.zone_interval import is_in
 
 
 class Zone:
@@ -10,18 +11,13 @@ class Zone:
         Zone.counter += 1
         self.area = None
         for area in areas:
-            if isinstance(areas[area][0], tuple):
-                for interval in areas[area]:
-                    if interval[0] <= number < interval[1]:
-                        self.area = area
-                        break
-            else:
-                if areas[area][0] <= number < areas[area][1]:
-                    self.area = area
-                    break
+            if is_in(areas[area], number):
+                self.area = area
+                print(area)
+                break
                 
         self.municipality = None
         for mp in municipalities:
-            if  municipalities[mp][0] <= number < municipalities[mp][1]:
+            if is_in(municipalities[mp], number):
                 self.municipality = mp
                 break

--- a/Scripts/datatypes/zone.py
+++ b/Scripts/datatypes/zone.py
@@ -10,9 +10,16 @@ class Zone:
         Zone.counter += 1
         self.area = None
         for area in areas:
-            if areas[area][0] <= number < areas[area][1]:
-                self.area = area
-                break
+            if isinstance(areas[area][0], tuple):
+                for interval in areas[area]:
+                    if interval[0] <= number < interval[1]:
+                        self.area = area
+                        break
+            else:
+                if areas[area][0] <= number < areas[area][1]:
+                    self.area = area
+                    break
+                
         self.municipality = None
         for mp in municipalities:
             if  municipalities[mp][0] <= number < municipalities[mp][1]:

--- a/Scripts/datatypes/zone.py
+++ b/Scripts/datatypes/zone.py
@@ -1,4 +1,4 @@
-from parameters.zone import areas, municipalities
+from parameters.zone import areas, area_aggregation, municipalities
 from utils.zone_interval import is_in
 
 
@@ -10,7 +10,7 @@ class Zone:
         self.index = Zone.counter
         Zone.counter += 1
         self.area = None
-        for area in areas:
+        for area in area_aggregation:
             if is_in(areas[area], number):
                 self.area = area
                 break

--- a/Scripts/datatypes/zone.py
+++ b/Scripts/datatypes/zone.py
@@ -13,7 +13,6 @@ class Zone:
         for area in areas:
             if is_in(areas[area], number):
                 self.area = area
-                print(area)
                 break
                 
         self.municipality = None

--- a/Scripts/datatypes/zone.py
+++ b/Scripts/datatypes/zone.py
@@ -1,0 +1,20 @@
+from parameters.zone import areas, municipalities
+
+
+class Zone:
+    counter = 0
+
+    def __init__(self, number):
+        self.number = number
+        self.index = Zone.counter
+        Zone.counter += 1
+        self.area = None
+        for area in areas:
+            if areas[area][0] <= number < areas[area][1]:
+                self.area = area
+                break
+        self.municipality = None
+        for mp in municipalities:
+            if  municipalities[mp][0] <= number < municipalities[mp][1]:
+                self.municipality = mp
+                break

--- a/Scripts/demand/trips.py
+++ b/Scripts/demand/trips.py
@@ -1,6 +1,5 @@
 import numpy
 import pandas
-import random
 
 import utils.log as log
 import parameters.zone as param
@@ -90,6 +89,7 @@ class DemandModel:
         list
             Person
         """
+        numpy.random.seed(param.population_draw)
         bounds = slice(0, self.zone_data.first_peripheral_zone)
         self.incmod = linear.IncomeModel(
             self.zone_data, bounds, self.age_groups, self.resultdata)
@@ -126,6 +126,7 @@ class DemandModel:
                         self.cm, self.incmod)
                     self.population.append(person)
                     self.zone_population[zone_number] += 1
+        numpy.random.seed(None)
 
     def generate_tours(self):
         """Generate vector of tours for each tour purpose.

--- a/Scripts/demand/trips.py
+++ b/Scripts/demand/trips.py
@@ -96,7 +96,7 @@ class DemandModel:
         self.population = []
         zones = self.zone_data.zone_numbers[bounds]
         self.zone_population = pandas.Series(0, zones)
-        for zone_number in zones:
+        for zone_number in self.zone_data.zone_numbers[bounds]:
             weights = [1]
             for age_group in self.age_groups:
                 key = "share_age_" + str(age_group[0]) + "-" + str(age_group[1])
@@ -122,7 +122,8 @@ class DemandModel:
                 if group != -1:
                     # Group -1 is under-7-year-olds and they have weights[0]
                     person = Person(
-                        zone_number, self.age_groups[group], self.gm,
+                        self.zone_data.zones[zone_number],
+                        self.age_groups[group], self.gm,
                         self.cm, self.incmod)
                     self.population.append(person)
                     self.zone_population[zone_number] += 1

--- a/Scripts/demand/trips.py
+++ b/Scripts/demand/trips.py
@@ -96,6 +96,7 @@ class DemandModel:
         self.population = []
         zones = self.zone_data.zone_numbers[bounds]
         self.zone_population = pandas.Series(0, zones)
+        person_id = 0
         for zone_number in zones:
             weights = [1]
             for age_group in self.age_groups:
@@ -122,11 +123,12 @@ class DemandModel:
                 if group != -1:
                     # Group -1 is under-7-year-olds and they have weights[0]
                     person = Person(
-                        self.zone_data.zones[zone_number],
+                        person_id, self.zone_data.zones[zone_number],
                         self.age_groups[group], self.gm,
                         self.cm, self.incmod)
                     self.population.append(person)
                     self.zone_population[zone_number] += 1
+                    person_id += 1
         numpy.random.seed(None)
 
     def generate_tours(self):

--- a/Scripts/demand/trips.py
+++ b/Scripts/demand/trips.py
@@ -96,7 +96,6 @@ class DemandModel:
         self.population = []
         zones = self.zone_data.zone_numbers[bounds]
         self.zone_population = pandas.Series(0, zones)
-        person_id = 0
         for zone_number in zones:
             weights = [1]
             for age_group in self.age_groups:
@@ -123,12 +122,11 @@ class DemandModel:
                 if group != -1:
                     # Group -1 is under-7-year-olds and they have weights[0]
                     person = Person(
-                        person_id, self.zone_data.zones[zone_number],
+                        self.zone_data.zones[zone_number],
                         self.age_groups[group], self.gm,
                         self.cm, self.incmod)
                     self.population.append(person)
                     self.zone_population[zone_number] += 1
-                    person_id += 1
         numpy.random.seed(None)
 
     def generate_tours(self):

--- a/Scripts/demand/trips.py
+++ b/Scripts/demand/trips.py
@@ -96,7 +96,7 @@ class DemandModel:
         self.population = []
         zones = self.zone_data.zone_numbers[bounds]
         self.zone_population = pandas.Series(0, zones)
-        for zone_number in self.zone_data.zone_numbers[bounds]:
+        for zone_number in zones:
             weights = [1]
             for age_group in self.age_groups:
                 key = "share_age_" + str(age_group[0]) + "-" + str(age_group[1])

--- a/Scripts/models/logit.py
+++ b/Scripts/models/logit.py
@@ -397,6 +397,9 @@ class ModeDestModel(LogitModel):
         
         Calculate mode choice probabilities for individual
         agent with individual dummy variable "car_users" included.
+
+        Additionally save and rescale logsum values for agent based accessibility 
+        analysis.
         
         Parameters
         ----------
@@ -407,9 +410,16 @@ class ModeDestModel(LogitModel):
         
         Returns
         -------
-        list
+        tuple
+            list
+                float
+                    Choice probabilities for purpose modes
             float
-                Choice probabilities for purpose modes
+                Total accessibility for individual (eur)
+            float
+                Sustainable modes accessibility for individual (eur)
+            float
+                Car accessibility for individual (eur)
         """
         mode_exps = {}
         mode_expsum = 0

--- a/Scripts/models/logit.py
+++ b/Scripts/models/logit.py
@@ -65,12 +65,7 @@ class LogitModel:
             self.resultdata.print_data(
                 pandas.Series(logsum, self.purpose.zone_numbers),
                 "sustainable_accessibility.txt", self.purpose.name)
-            try:
-                b = self.dest_choice_param["car"]["impedance"]["cost"]
-            except KeyError:
-                # School tours do not have a constant cost parameter
-                # Use value of time conversion from CBA guidelines instead
-                b = -0.31690253
+            b = self._get_cost_util_coefficient()
             try:
                 # Convert utility into euros
                 money_utility = 1 / b
@@ -270,6 +265,14 @@ class LogitModel:
                 zdata.get_data(i, self.bounds, generation) + 1, b[i])
         return exps
 
+    def _get_cost_util_coefficient(self):
+        try:
+            b = self.dest_choice_param["car"]["impedance"]["cost"]
+        except KeyError:
+            # School tours do not have a constant cost parameter
+            # Use value of time conversion from CBA guidelines instead
+            b = -0.31690253
+        return b
 
 class ModeDestModel(LogitModel):
     """Nested logit model with mode choice in upper level.
@@ -449,12 +452,7 @@ class ModeDestModel(LogitModel):
         logsum = numpy.log(mode_expsum)
         sust_logsum = numpy.log(sust_expsum)
         car_logsum = numpy.log(car_expsum)
-        try:
-            b = self.dest_choice_param["car"]["impedance"]["cost"]
-        except KeyError:
-            # School tours do not have a constant cost parameter
-            # Use value of time conversion from CBA guidelines instead
-            b = -0.31690253
+        b = self._get_cost_util_coefficient()
         if isinstance(b, tuple):
             # Separate params for cap region and surrounding
             # Choose based location

--- a/Scripts/models/logit.py
+++ b/Scripts/models/logit.py
@@ -457,11 +457,7 @@ class ModeDestModel(LogitModel):
             money_utility = 1 / b
         except TypeError:
             # Separate params for cap region and surrounding
-            # Choose based location
-            if self.lbounds.stop < zone:
-                money_utility = 1 / b[0]
-            else:
-                money_utility = 1 / b[1]
+            money_utility = 1 / b[0] if self.lbounds.stop < zone else 1 / b[1]
         money_utility /= self.mode_choice_param["car"]["log"]["logsum"]
         total = -money_utility * logsum
         sust = -money_utility * sust_logsum

--- a/Scripts/models/logit.py
+++ b/Scripts/models/logit.py
@@ -413,16 +413,15 @@ class ModeDestModel(LogitModel):
         
         Returns
         -------
-        tuple
-            list
-                float
-                    Choice probabilities for purpose modes
+        list
             float
-                Total accessibility for individual (eur)
-            float
-                Sustainable modes accessibility for individual (eur)
-            float
-                Car accessibility for individual (eur)
+                Choice probabilities for purpose modes
+        float
+            Total accessibility for individual (eur)
+        float
+            Sustainable modes accessibility for individual (eur)
+        float
+            Car accessibility for individual (eur)
         """
         mode_exps = {}
         mode_expsum = 0
@@ -453,15 +452,16 @@ class ModeDestModel(LogitModel):
         sust_logsum = numpy.log(sust_expsum)
         car_logsum = numpy.log(car_expsum)
         b = self._get_cost_util_coefficient()
-        if isinstance(b, tuple):
+        try:
+            # Convert utility into euros
+            money_utility = 1 / b
+        except TypeError:
             # Separate params for cap region and surrounding
             # Choose based location
             if self.lbounds.stop < zone:
                 money_utility = 1 / b[0]
             else:
                 money_utility = 1 / b[1]
-        else:
-            money_utility = 1 / b
         money_utility /= self.mode_choice_param["car"]["log"]["logsum"]
         total = -money_utility * logsum
         sust = -money_utility * sust_logsum

--- a/Scripts/modelsystem.py
+++ b/Scripts/modelsystem.py
@@ -492,7 +492,7 @@ class AgentModelSystem(ModelSystem):
             0, self.zdata_forecast.zone_numbers[self.dm.cm.bounds])
         for person in self.dm.population:
             person.decide_car_use()
-            car_users[person.zone] += person.is_car_user
+            car_users[person.zone.number] += person.is_car_user
             person.add_tours(self.dm.purpose_dict, tour_probs)
             for tour in person.tours:
                 tour.choose_mode(person.is_car_user)

--- a/Scripts/modelsystem.py
+++ b/Scripts/modelsystem.py
@@ -543,17 +543,13 @@ class AgentModelSystem(ModelSystem):
         if is_last_iteration:
             random.seed(zone_param.population_draw)
             self.dm.incmod.predict()
-            random.seed(None) 
-            line = "\t".join([
-                "person_id", "age_group", "gender", "car_user", "income",
-                "number", "area", "municipality", "nr_tours",
-                "total_access", "sustainable_access", "car_access"
-                ])
+            random.seed(None)
             fname = "agents"
-            self.resultdata.print_line(line, fname)
+            header = "\t".join(self.dm.population[0].attr)
+            self.resultdata.print_line(header, fname)
             for person in self.dm.population:
                 person.calc_income()
-                person.write_file(self.resultdata, fname)
+                self.resultdata.print_line(person.__str__(), fname)
             log.info("Results printed to file ".format(fname))
         log.info("Demand calculation completed")
 

--- a/Scripts/modelsystem.py
+++ b/Scripts/modelsystem.py
@@ -549,7 +549,7 @@ class AgentModelSystem(ModelSystem):
             self.resultdata.print_line(header, fname)
             for person in self.dm.population:
                 person.calc_income()
-                self.resultdata.print_line(person.__str__(), fname)
+                self.resultdata.print_line(str(person), fname)
             log.info("Results printed to file ".format(fname))
         log.info("Demand calculation completed")
 

--- a/Scripts/modelsystem.py
+++ b/Scripts/modelsystem.py
@@ -532,7 +532,7 @@ class AgentModelSystem(ModelSystem):
             self.dm.incmod.predict()
             random.seed(None) 
             line = "\t".join([
-                "age", "gender", "car_user", "income",
+                "person_id", "age", "gender", "car_user", "income",
                 "number", "area", "municipality", "nr_tours",
                 "total_access", "sustainable_access", "car_access"
                 ])

--- a/Scripts/modelsystem.py
+++ b/Scripts/modelsystem.py
@@ -3,6 +3,7 @@ import multiprocessing
 import os
 import numpy
 import pandas
+import random
 from collections import defaultdict
 
 import utils.log as log
@@ -436,6 +437,7 @@ class AgentModelSystem(ModelSystem):
 
     def _init_demand_model(self):
         log.info("Creating synthetic population")
+        random.seed(zone_param.population_draw)
         return DemandModel(self.zdata_forecast, self.resultdata, is_agent_model=True)
 
     def _add_internal_demand(self, previous_iter_impedance, is_last_iteration):
@@ -457,6 +459,7 @@ class AgentModelSystem(ModelSystem):
             secondary destinations are calculated for all modes
         """
         log.info("Demand calculation started...")
+        random.seed(None)
         self.dm.cm.calc_basic_prob()
         self.travel_modes = set()
         for purpose in self.dm.tour_purposes:
@@ -525,9 +528,11 @@ class AgentModelSystem(ModelSystem):
             for tour in person.tours:
                 self.dtm.add_demand(tour)
         if is_last_iteration:
+            random.seed(zone_param.population_draw)
             self.dm.incmod.predict()
             for person in self.dm.population:
                 person.calc_income()
+            random.seed(None)
         log.info("Demand calculation completed")
 
     def _distribute_tours(self, mode, origs, sec_dest_tours, impedance):

--- a/Scripts/modelsystem.py
+++ b/Scripts/modelsystem.py
@@ -554,8 +554,8 @@ class AgentModelSystem(ModelSystem):
             for person in self.dm.population:
                 person.calc_income()
                 person.write_file(self.resultdata, fname)
-            log.info("Results printed to file ".format(fname)) 
-        log.info("Demand calculation completed")        
+            log.info("Results printed to file ".format(fname))
+        log.info("Demand calculation completed")
 
     def _distribute_tours(self, mode, origs, sec_dest_tours, impedance):
         sec_dest_purpose = self.dm.purpose_dict["hoo"]

--- a/Scripts/modelsystem.py
+++ b/Scripts/modelsystem.py
@@ -532,7 +532,7 @@ class AgentModelSystem(ModelSystem):
             self.dm.incmod.predict()
             random.seed(None) 
             line = "\t".join([
-                "person_id", "age", "gender", "car_user", "income",
+                "person_id", "age_group", "gender", "car_user", "income",
                 "number", "area", "municipality", "nr_tours",
                 "total_access", "sustainable_access", "car_access"
                 ])

--- a/Scripts/parameters/zone.py
+++ b/Scripts/parameters/zone.py
@@ -1,6 +1,11 @@
 # Share of demand that will be simulated in agent model
 agent_demand_fraction = 1.0
 
+# Seed number for population attributes:
+# int = fixed seed and same population for each run
+# None = different population for each run
+population_draw = 31
+
 ### DEMAND MODEL REFERENCES ###
 
 tour_purposes = (

--- a/Scripts/tests/unit/test_person.py
+++ b/Scripts/tests/unit/test_person.py
@@ -26,7 +26,10 @@ class PersonTest(unittest.TestCase):
             gen_model = GenMod()
             def __init__(self, name):
                 self.name = name
-        p = Person(101, (18, 29), GenMod(), None, ZoneData())
+        class Zone:
+            number = 101
+            index = 0
+        p = Person(Zone(), (18, 29), GenMod(), None, ZoneData())
         p.is_car_user = True
         purposes = {
             "hw": Purpose("hw"),

--- a/Scripts/tests/unit/test_person.py
+++ b/Scripts/tests/unit/test_person.py
@@ -29,7 +29,7 @@ class PersonTest(unittest.TestCase):
         class Zone:
             number = 101
             index = 0
-        p = Person(Zone(), (18, 29), GenMod(), None, ZoneData())
+        p = Person(0, Zone(), (18, 29), GenMod(), None, ZoneData())
         p.is_car_user = True
         purposes = {
             "hw": Purpose("hw"),

--- a/Scripts/tests/unit/test_person.py
+++ b/Scripts/tests/unit/test_person.py
@@ -29,7 +29,7 @@ class PersonTest(unittest.TestCase):
         class Zone:
             number = 101
             index = 0
-        p = Person(0, Zone(), (18, 29), GenMod(), None, ZoneData())
+        p = Person(Zone(), (18, 29), GenMod(), None, ZoneData())
         p.is_car_user = True
         purposes = {
             "hw": Purpose("hw"),


### PR DESCRIPTION
## Methods to print accessibility values and other results from agent model.
Replaces closed PR #266 as I had some serious difficulties with version control.

## Accessibility
Accessibility defined here as expected maximum utility from mode choice model, which is the denominator of the logit choice model (logsum). Logsum is calculated for each agent and tour in model after individual dummies are added. Tour utilities are summed for each agent separately for car, sustainable modes and all modes.

### Scaling of accessibility
[Dong et al. 2006](https://xjdong.github.io/papers/2006_TRA_Activity%20Accessibility.pdf) and [Miller 2020](https://www.itf-oecd.org/sites/default/files/docs/measuring-accessibility-methods-issues_1.pdf) argue that accessibility measure should satisfy two conditions:

1. The scale condition requires all the calculated accessibility values to share the same scale or same unit.
2. The level condition requires the values to have a consistent benchmark utility. This is necessary because the underlying model
does not depend on the absolute size of utility but on the utility differences of the available alternatives. Any constant could be added to all alternatives utilities without changing the choice model probabilities
I would interpret these so that logsum between tour purposes (different model specification) cannot be compared, because the level is arbitrary and does not describe relative importance of trip.

Here following #265 accessibility scale is unified by translating utility into money or time, therefore condition first is satisfied. Second is still work in progress, as it would mean that summing accessibility for trip purposes won't reflect their importance to agents? However, accessibility values will be updated later. 

Additionally one should consider how marginal utility of money differs in income groups, as pointed out [here](https://link.springer.com/article/10.1007/s11116-017-9853-4). 
