### PR TITLE
Fix filename

### DIFF
--- a/Scripts/assignment/emme_assignment.py
+++ b/Scripts/assignment/emme_assignment.py
@@ -192,7 +192,7 @@ class EmmeAssignmentModel(AssignmentModel):
                         transit_dists[mode] += freq * segment.link.length
                         transit_times[mode] += freq * segment["@base_timtr"]
         resultdata.print_data(transit_dists, "transit_kms.txt", "dist")
-        resultdata.print_data(transit_times, "transit_kms.txt", "time")
+        resultdata.print_data(transit_times, "transit_minutes.txt", "time")
 
     def calc_transit_cost(self, fares, peripheral_cost, default_cost=None):
         """Calculate transit zone cost matrix.


### PR DESCRIPTION
Previously, transit distances were overwritten by transit times in EmmeAssignment.

@zptro, is "minutes" the correct unit?

Not tested with Emme!