### PR TITLE
Add vans and save demand matrices before last assignment

### DIFF
--- a/Scripts/modelsystem.py
+++ b/Scripts/modelsystem.py
@@ -291,14 +291,15 @@ class ModelSystem:
                 trip_sum[mode] / sum_all, "origins_shares.txt", mode)
             mode_shares[mode] = trip_sum[mode].sum() / sum_all.sum()
         self.mode_share.append(mode_shares)
+        for ap in self.ass_model.assignment_periods:
+            self.dtm.add_vans(ap.name, self.zdata_forecast.nr_zones)
+            if iteration=="last":
+                self._save_demand_to_omx(ap.name)
 
         # Calculate and return traffic impedance
         for ap in self.ass_model.assignment_periods:
             tp = ap.name
             log.info("Assigning period " + tp)
-            self.dtm.add_vans(tp, self.zdata_forecast.nr_zones)
-            if iteration=="last":
-                self._save_demand_to_omx(ap.name)
             impedance[tp] = ap.assign(self.dtm.demand[tp], iteration)
             if tp == "aht":
                 self._update_ratios(impedance[tp], tp)

--- a/Scripts/modelsystem.py
+++ b/Scripts/modelsystem.py
@@ -291,6 +291,8 @@ class ModelSystem:
                 trip_sum[mode] / sum_all, "origins_shares.txt", mode)
             mode_shares[mode] = trip_sum[mode].sum() / sum_all.sum()
         self.mode_share.append(mode_shares)
+
+        # Add vans and save demand matrices
         for ap in self.ass_model.assignment_periods:
             self.dtm.add_vans(ap.name, self.zdata_forecast.nr_zones)
             if iteration=="last":


### PR DESCRIPTION
This is hopefully the last time I change this. The idea is to save all demand matrices before end assignment starts, so that end assignment can be re-run if it crashes for some reason. The first time I implemented this (https://github.com/HSLdevcom/helmet-model-system/pull/237/commits/05c91e538bbb0f0bbd380cb2fc6b088dbdd6bdd9), I had forgot that vans are added later. When I tried to fix this problem, I just moved saving of demand matrices back into the assignment loop, so the original idea was lost.