### PR TITLE
Changed handling of transit trip part matrices

### DIFF
--- a/Scripts/assignment/assignment_period.py
+++ b/Scripts/assignment/assignment_period.py
@@ -319,9 +319,7 @@ class AssignmentPeriod(Period):
     def _damp(self, travel_time, fw_time):
         """Reduce the impact from first waiting time on total travel time."""
         wt_weight = param.waiting_time_perception_factor
-        # Calculate transit travel time where first waiting time is damped
-        dtt = travel_time + wt_weight*((5./3.*fw_time)**0.8 - fw_time)
-        return dtt
+        return travel_time + wt_weight*((5./3.*fw_time)**0.8 - fw_time)
 
     def _extract_timecost_from_gcost(self, ass_class):
         """Remove monetary cost from generalized cost."""

--- a/Scripts/assignment/datatypes/transit.py
+++ b/Scripts/assignment/datatypes/transit.py
@@ -16,33 +16,25 @@ class TransitSpecification:
     ----------
     ass_class : str
         Assignment class (transit_work/transit_leisure)
-    demand_mtx : dict
+    demand_mtx_id : str
+        Emme matrix id for demand matrix
+    time_mtx_id : str
+        Emme matrix id for time matrix
+    dist_mtx_id : str
+        Emme matrix id for distance matrix
+    trip_part : dict
         key : str
-            Assignment class (transit_work/transit_leisure)
+            Impedance type (inv_time/aux_time/num_board/...)
         value : dict
             id : str
                 Emme matrix id
             description : dict
                 Matrix description
-    result_mtx : dict
-        key : str
-            Impedance type (time/cost/dist)
-        value : dict
-            key : str
-                Assignment class (transit_work/transit_leisure)
-            value : dict
-                id : str
-                    Emme matrix id
-                description : dict
-                    Matrix description
     count_zone_boardings : bool (optional)
         Whether assignment is performed only to count fare zone boardings
-    is_last_iteration : bool (optional)
-        If this is the last iteration, some other assignment parameters can be defined
     """
-    def __init__(self, ass_class, demand_mtx, result_mtx, count_zone_boardings=False):
-        self.demand_mtx = demand_mtx
-        self.result_mtx = result_mtx
+    def __init__(self, ass_class, demand_mtx_id, time_mtx_id, dist_mtx_id,
+                 trip_part, count_zone_boardings=False):
         no_penalty = dict.fromkeys(["at_nodes", "on_lines", "on_segments"])
         no_penalty["global"] = {
             "penalty": 0, 
@@ -51,7 +43,7 @@ class TransitSpecification:
         self.transit_spec = {
             "type": "EXTENDED_TRANSIT_ASSIGNMENT",
             "modes": param.transit_assignment_modes,
-            "demand": self.demand_mtx[ass_class]["id"],
+            "demand": demand_mtx_id,
             "waiting_time": {
                 "headway_fraction": param.standard_headway_fraction,
                 "effective_headways": "hdw",
@@ -102,8 +94,8 @@ class TransitSpecification:
                 "type": "EXTENDED_TRANSIT_MATRIX_RESULTS",
                 "by_mode_subset": {
                     "modes": param.transit_modes,
-                    "distance": self.result_mtx["dist"][ass_class]["id"],
-                    "actual_total_boarding_costs": self.result_mtx["trip_part"][ass_class + "_board_cost"]["id"],
+                    "distance": dist_mtx_id,
+                    "actual_total_boarding_costs": trip_part["board_cost"]["id"],
                 },
             }
         else:
@@ -111,17 +103,17 @@ class TransitSpecification:
             jlevel2 = JourneyLevel(boarded=True, ass_class=ass_class)
             mtx_results_spec = {
                 "type": "EXTENDED_TRANSIT_MATRIX_RESULTS",
-                "total_impedance": self.result_mtx["time"][ass_class]["id"],
-                "total_travel_time": self.result_mtx["trip_part"][ass_class + "_total_time"]["id"],
-                "actual_first_waiting_times": self.result_mtx["trip_part"][ass_class + "_fw_time"]["id"],
-                "actual_total_waiting_times": self.result_mtx["trip_part"][ass_class + "_tw_time"]["id"],
+                "total_impedance": time_mtx_id,
+                "total_travel_time": trip_part["total_time"]["id"],
+                "actual_first_waiting_times": trip_part["fw_time"]["id"],
+                "actual_total_waiting_times": trip_part["tw_time"]["id"],
                 "by_mode_subset": {
                     "modes": param.transit_assignment_modes,
-                    "distance": self.result_mtx["dist"][ass_class]["id"],
-                    "avg_boardings": self.result_mtx["trip_part"][ass_class + "_num_board"]["id"],
-                    "actual_total_boarding_times": self.result_mtx["trip_part"][ass_class + "_board_time"]["id"],
-                    "actual_in_vehicle_times": self.result_mtx["trip_part"][ass_class + "_inv_time"]["id"],
-                    "actual_aux_transit_times": self.result_mtx["trip_part"][ass_class + "_aux_time"]["id"],
+                    "distance": dist_mtx_id,
+                    "avg_boardings": trip_part["num_board"]["id"],
+                    "actual_total_boarding_times": trip_part["board_time"]["id"],
+                    "actual_in_vehicle_times": trip_part["inv_time"]["id"],
+                    "actual_aux_transit_times": trip_part["aux_time"]["id"],
                 },
             }
 

--- a/Scripts/parameters/assignment.py
+++ b/Scripts/parameters/assignment.py
@@ -483,68 +483,70 @@ emme_result_mtx = {
             "description": "van travel generalized cost",
         },
     },
-    "trip_part":{
-        "transit_work_inv_time": {
+    "trip_part_transit_work":{
+        "inv_time": {
             "id": 51,
             "description": "transit in-vehicle time",
         },
-        "transit_work_aux_time": {
+        "aux_time": {
             "id": 52,
             "description": "transit auxilliary time",
         },
-        "transit_work_tw_time": {
+        "tw_time": {
             "id": 53,
             "description": "transit total waiting time",
         },
-        "transit_work_fw_time": {
+        "fw_time": {
             "id": 54,
             "description": "transit first waiting time",
         },
-        "transit_work_board_time": {
+        "board_time": {
             "id": 55,
             "description": "transit boarding time",
         },
-        "transit_work_total_time": {
+        "total_time": {
             "id": 56,
             "description": "transit unweighted travel time",
         },
-        "transit_work_num_board": {
+        "num_board": {
             "id": 57,
             "description": "transit trip number of boardings",
         },
-        "transit_work_board_cost": {
+        "board_cost": {
             "id": 58,
             "description": "transit boarding cost",
         },
-        "transit_leisure_inv_time": {
+    },
+    "trip_part_transit_leisure":{
+        "inv_time": {
             "id": 61,
             "description": "transit in-vehicle time",
         },
-        "transit_leisure_aux_time": {
+        "aux_time": {
             "id": 62,
             "description": "transit auxilliary time",
         },
-        "transit_leisure_tw_time": {
+        "tw_time": {
             "id": 63,
             "description": "transit total waiting time",
         },
-        "transit_leisure_fw_time": {
+        "fw_time": {
             "id": 64,
             "description": "transit first waiting time",
         },
-        "transit_leisure_board_time": {
+        "board_time": {
             "id": 65,
             "description": "transit boarding time",
         },
-        "transit_leisure_total_time": {
+        "total_time": {
             "id": 66,
             "description": "transit unweighted travel time",
         },
-        "transit_leisure_num_board": {
+        "num_board": {
             "id": 67,
             "description": "transit trip number of boardings",
         },
-        "transit_leisure_board_cost": {
+        "board_cost": {
             "id": 68,
             "description": "transit boarding cost",
         },


### PR DESCRIPTION
Restructured the matrix dict so that words"transit_work" and "transit_leisure" are not repeated so many times.