### PR TITLE
Introduce "modification scenario" and copy this to four new scenarios

### DIFF
--- a/Scripts/assignment/assignment_period.py
+++ b/Scripts/assignment/assignment_period.py
@@ -20,6 +20,7 @@ class AssignmentPeriod(Period):
         self.emme_scenario = emme_context.modeller.emmebank.scenario(
             emme_scenario)
         self.emme_project = emme_context
+        self._save_matrices = save_matrices
         if save_matrices:
             self.demand_mtx = copy.deepcopy(demand_mtx)
             self.result_mtx = copy.deepcopy(result_mtx)
@@ -92,24 +93,36 @@ class AssignmentPeriod(Period):
             self._set_bike_vdfs()
             self._assign_bikes(self.result_mtx["dist"]["bike"]["id"], "all")
             self._set_car_and_transit_vdfs()
+            if not self._save_matrices:
+                self._calc_background_traffic()
             self._assign_cars(param.stopping_criteria_coarse)
             self._calc_extra_wait_time()
             self._assign_transit()
         elif iteration==0:
+            self._set_car_and_transit_vdfs()
+            if not self._save_matrices:
+                self._calc_background_traffic()
             self._assign_cars(param.stopping_criteria_coarse)
             self._calc_extra_wait_time()
             self._assign_transit()
         elif iteration==1:
+            if not self._save_matrices:
+                self._set_car_and_transit_vdfs()
             self._assign_cars(param.stopping_criteria_coarse)
             self._calc_extra_wait_time()
             self._assign_transit()
             self._calc_background_traffic(include_trucks=True)
         elif isinstance(iteration, int) and iteration>1:
+            if not self._save_matrices:
+                self._set_car_and_transit_vdfs()
+                self._calc_background_traffic(include_trucks=True)
             self._assign_cars(
                 param.stopping_criteria_coarse, lightweight=True)
             self._calc_extra_wait_time()
             self._assign_transit()
         elif iteration=="last":
+            if not self._save_matrices:
+                self._set_car_and_transit_vdfs()
             self._calc_background_traffic()
             self._assign_cars(param.stopping_criteria_fine)
             self._calc_boarding_penalties(is_last_iteration=True)

--- a/Scripts/assignment/emme_assignment.py
+++ b/Scripts/assignment/emme_assignment.py
@@ -45,16 +45,23 @@ class EmmeAssignmentModel(AssignmentModel):
 
     def prepare_network(self):
         """Create matrices, extra attributes and calc background variables."""
-        self.day_scenario = self.emme_project.copy_scenario(
-            self.mod_scenario, self.mod_scenario.number + 1,
-            self.mod_scenario.title + '_' + "vrk",
-            overwrite=True, copy_paths=False, copy_strategies=False)
+        if self.save_matrices:
+            self.day_scenario = self.emme_project.copy_scenario(
+                self.mod_scenario, self.mod_scenario.number + 1,
+                self.mod_scenario.title + '_' + "vrk",
+                overwrite=True, copy_paths=False, copy_strategies=False)
+        else:
+            self.day_scenario = self.mod_scenario
         self.assignment_periods = []
         for i, tp in enumerate(["aht", "pt", "iht"]):
-            scen_id = self.mod_scenario.number + i + 2
-            self.emme_project.copy_scenario(
-                self.mod_scenario, scen_id, self.mod_scenario.title + '_' + tp,
-                overwrite=True, copy_paths=False, copy_strategies=False)
+            if self.save_matrices:
+                scen_id = self.mod_scenario.number + i + 2
+                self.emme_project.copy_scenario(
+                    self.mod_scenario, scen_id,
+                    self.mod_scenario.title + '_' + tp,
+                    overwrite=True, copy_paths=False, copy_strategies=False)
+            else:
+                scen_id = self.mod_scenario.number
             self.assignment_periods.append(AssignmentPeriod(
                 tp, scen_id, self.emme_project,
                 save_matrices=self.save_matrices))

--- a/Scripts/assignment/emme_assignment.py
+++ b/Scripts/assignment/emme_assignment.py
@@ -38,17 +38,26 @@ class EmmeAssignmentModel(AssignmentModel):
         self.save_matrices = save_matrices
         self.first_matrix_id = first_matrix_id if save_matrices else 0
         self.emme_project = emme_context
-        self.assignment_periods = [AssignmentPeriod(
-                tp, first_scenario_id + i + 2,
-                emme_context, save_matrices=save_matrices)
-            for i, tp in enumerate(["aht", "pt", "iht"])]
         # default value for dist, modelsystem sets new from zonedata
         self.dist_unit_cost = param.dist_unit_cost
-        self.day_scenario = self.emme_project.modeller.emmebank.scenario(
-            first_scenario_id + 1)
+        self.mod_scenario = self.emme_project.modeller.emmebank.scenario(
+            first_scenario_id)
 
     def prepare_network(self):
         """Create matrices, extra attributes and calc background variables."""
+        self.day_scenario = self.emme_project.copy_scenario(
+            self.mod_scenario, self.mod_scenario.number + 1,
+            self.mod_scenario.title + '_' + "vrk",
+            overwrite=True, copy_paths=False, copy_strategies=False)
+        self.assignment_periods = []
+        for i, tp in enumerate(["aht", "pt", "iht"]):
+            scen_id = self.mod_scenario.number + i + 2
+            self.emme_project.copy_scenario(
+                self.mod_scenario, scen_id, self.mod_scenario.title + '_' + tp,
+                overwrite=True, copy_paths=False, copy_strategies=False)
+            self.assignment_periods.append(AssignmentPeriod(
+                tp, scen_id, self.emme_project,
+                save_matrices=self.save_matrices))
         for i, ap in enumerate(self.assignment_periods):
             tag = ap.name if self.save_matrices else ""
             id_hundred = 100*i + self.first_matrix_id
@@ -90,7 +99,7 @@ class EmmeAssignmentModel(AssignmentModel):
     @property
     def zone_numbers(self):
         """Numpy array of all zone numbers.""" 
-        return numpy.array(self.assignment_periods[0].emme_scenario.zone_numbers)
+        return numpy.array(self.mod_scenario.zone_numbers)
 
     @property
     def mapping(self):

--- a/Scripts/assignment/emme_bindings/emme_project.py
+++ b/Scripts/assignment/emme_bindings/emme_project.py
@@ -21,6 +21,8 @@ class EmmeProject:
         self.modeller = _m.Modeller(emme_desktop)
         log.info("Emme started")
         self.path = os.path.dirname(self.modeller.emmebank.path)
+        self.copy_scenario = self.modeller.tool(
+            "inro.emme.data.scenario.copy_scenario")
         self.create_matrix = self.modeller.tool(
             "inro.emme.data.matrix.create_matrix")
         self.copy_matrix = self.modeller.tool(

--- a/Scripts/helmet_validate_inputfiles.py
+++ b/Scripts/helmet_validate_inputfiles.py
@@ -75,8 +75,8 @@ def main(args):
     base_zonedata = ZoneData(base_zonedata_path, assignment_model.zone_numbers)
     # Check base matrices
     matrixdata = MatrixData(base_matrices_path)
-    for ap in assignment_model.assignment_periods:
-        with matrixdata.open("demand", ap.name, assignment_model.zone_numbers) as mtx:
+    for tp in ("aht", "pt", "iht"):
+        with matrixdata.open("demand", tp, assignment_model.zone_numbers) as mtx:
             for ass_class in param.transport_classes:
                 a = mtx[ass_class]
 

--- a/Scripts/tests/unit/test_assignment.py
+++ b/Scripts/tests/unit/test_assignment.py
@@ -12,25 +12,24 @@ from datahandling.resultdata import ResultsData
 class EmmeAssignmentTest(unittest.TestCase):
     def test_assignment(self):
         context = MockProject()
-        for scenario in context.modeller.emmebank.scenarios():
-            network = scenario.get_network()
-            for idx in ('c', 'b'):
-                network.create_mode(idx)
-            network.create_transit_vehicle(0, 'b')
-            for idx in (101, 4003, 16001, 16002):
-                node = network.create_node(idx, is_centroid=True)
-                node.label = 'A'
-            for idx in range(1, 5):
-                node = network.create_node(idx)
-                node.label = 'A'
-            for od in ((1, 2), (2, 3), (3, 4)):
-                link = network.create_link(*od, modes=['c', 'b'])
-                link.type = 138
-                link.length = 3.5
-            line = network.create_transit_line("1", 0, [1, 2])
-            line.headway = 5
-            line = network.create_transit_line("2", 0, [2, 3])
-            line.headway = 10
+        network = context.modeller.emmebank.scenario(19).get_network()
+        for idx in ('c', 'b'):
+            network.create_mode(idx)
+        network.create_transit_vehicle(0, 'b')
+        for idx in (101, 4003, 16001, 16002):
+            node = network.create_node(idx, is_centroid=True)
+            node.label = 'A'
+        for idx in range(1, 5):
+            node = network.create_node(idx)
+            node.label = 'A'
+        for od in ((1, 2), (2, 3), (3, 4)):
+            link = network.create_link(*od, modes=['c', 'b'])
+            link.type = 138
+            link.length = 3.5
+        line = network.create_transit_line("1", 0, [1, 2])
+        line.headway = 5
+        line = network.create_transit_line("2", 0, [2, 3])
+        line.headway = 10
         ass_model = EmmeAssignmentModel(context, 19, save_matrices=True)
         ass_model.prepare_network()
         fares = {
@@ -58,7 +57,7 @@ class EmmeAssignmentTest(unittest.TestCase):
         ass_model.init_assign(demand)
         resultdata = ResultsData(os.path.join(
             os.path.dirname(os.path.realpath(__file__)),
-            "..", "test_data", "Results", "2016_test"))
+            "..", "test_data", "Results", "test"))
         ass_model.aggregate_results(resultdata)
         ass_model.calc_noise()
         resultdata.flush()


### PR DESCRIPTION
Assume that network is stored in one scenario in Emme, the "modification scenario".

If parameter `save_matrices` is true:
- Copy the "modification scenario" (scenario number n) to four next scenario numbers, overwriting these if they already exist
- Do assignments in time-period specific scenarios (aht=n+2, pt=n+3, iht=n+4) and aggregate to whole day in scenario n+1

Else:
- Do all assignments in "modification scenario"
- Background traffic and vdfs need to be set before each assignment


Background traffic calculation could be refactored in future PR, calculating it only once for each time-period and storing it in extra attribute. Volume delay functions should then be modified to use extra function parameters.