### PR TITLE
Normalize workforce accessibility

### DIFF
--- a/Scripts/models/logit.py
+++ b/Scripts/models/logit.py
@@ -350,9 +350,12 @@ class ModeDestModel(LogitModel):
             "accessibility.txt", self.purpose.name)
         if self.purpose.name == "wh":
             # Transform into person equivalents
-            workforce = pandas.Series(
-                mode_expsum**(1/self.mode_choice_param["car"]["log"]["logsum"]),
-                self.purpose.zone_numbers)
+            param = self.mode_choice_param
+            normalization = 1 / sum([param[mode]["constant"][0]
+                for mode in param])
+            workforce = ((normalization*mode_expsum)
+                         **(1/param["car"]["log"]["logsum"]))
+            workforce = pandas.Series(workforce, self.purpose.zone_numbers)
             self.resultdata.print_data(
                 workforce, "workforce_accessibility.txt", self.purpose.name)
             workplaces = self.zone_data["workplaces"][self.bounds]


### PR DESCRIPTION
Workforce accessibility is logsum from theoretical work-home tour model, transformed into person equivalents. However, in the mode choice model each mode has a constant (i.e., a factor for each exponential in the logsum). To get a value that resembles the number of inhabitants in the region better, this PR divides the accessibility measure by the sum of these constants. This can be regarded as theoretically dubious, but wtf.