### PR TITLE
Separate accessibility calculation class

### DIFF
--- a/Scripts/datatypes/purpose.py
+++ b/Scripts/datatypes/purpose.py
@@ -121,7 +121,7 @@ class TourPurpose(Purpose):
         else:
             self.model = logit.ModeDestModel(
                 zone_data, self, resultdata, is_agent_model)
-            self.access_model = logit.AccessibilityModel(
+            self.accessibility_model = logit.AccessibilityModel(
                 zone_data, self, resultdata, is_agent_model)
         self.modes = self.model.mode_choice_param.keys()
         self.histograms = {mode: TourLengthHistogram() for mode in self.modes}

--- a/Scripts/datatypes/purpose.py
+++ b/Scripts/datatypes/purpose.py
@@ -121,6 +121,8 @@ class TourPurpose(Purpose):
         else:
             self.model = logit.ModeDestModel(
                 zone_data, self, resultdata, is_agent_model)
+            self.access_model = logit.AccessibilityModel(
+                zone_data, self, resultdata, is_agent_model)
         self.modes = self.model.mode_choice_param.keys()
         self.histograms = {mode: TourLengthHistogram() for mode in self.modes}
         self.aggregates = {mode: MatrixAggregator(zone_data.zone_numbers)

--- a/Scripts/datatypes/tour.py
+++ b/Scripts/datatypes/tour.py
@@ -114,12 +114,15 @@ class Tour(object):
         is_car_user : bool
             Whether the person is car user or not
         """
-        probs, total, sust = self.purpose.model.calc_individual_mode_prob(
+        probs, accessibility = self.purpose.model.calc_individual_mode_prob(
                 is_car_user, self.position[0])
         self._mode_idx = numpy.searchsorted(probs.cumsum(), self._mode_draw)
         self.purpose.generated_tours[self.mode][self.position[0]] += 1
-        self.total_access = total
-        self.sustainable_access = sust
+        self.total_access = accessibility
+
+    @property
+    def sustainable_access(self):
+        return -self.purpose.sustainable_accessibility[self.position[0]]
 
     def choose_destination(self, sec_dest_tours):
         """Choose primary destination for the tour.

--- a/Scripts/datatypes/tour.py
+++ b/Scripts/datatypes/tour.py
@@ -122,7 +122,7 @@ class Tour(object):
 
     @property
     def sustainable_access(self):
-        return -self.purpose.sustainable_accessibility[self.position[0]]
+        return -self.purpose.sustainable_access[self.orig]
 
     def choose_destination(self, sec_dest_tours):
         """Choose primary destination for the tour.

--- a/Scripts/models/logit.py
+++ b/Scripts/models/logit.py
@@ -435,7 +435,7 @@ class ModeDestModel(LogitModel):
         except KeyError:
             # School tours do not have a constant cost parameter
             # Use value of time conversion from CBA guidelines instead
-            b = -0.31690253
+            b = -0.46738697
         return b
 
 

--- a/Scripts/models/logit.py
+++ b/Scripts/models/logit.py
@@ -440,7 +440,7 @@ class ModeDestModel(LogitModel):
 
 
 class AccessibilityModel(ModeDestModel):
-    def calc_basic_prob(self, impedance):
+    def calc_accessibility(self, impedance):
         """Calculate logsum-based accessibility measures.
 
         Individual dummy variables are not included.

--- a/Scripts/modelsystem.py
+++ b/Scripts/modelsystem.py
@@ -112,7 +112,8 @@ class ModelSystem:
                     purpose, previous_iter_impedance)
                 purpose.calc_prob(purpose_impedance)
                 if is_last_iteration and purpose.dest != "source":
-                    purpose.access_model.calc_accessibility(purpose_impedance)
+                    purpose.accessibility_model.calc_accessibility(
+                        purpose_impedance)
         
         # Tour generation
         self.dm.generate_tours()
@@ -132,7 +133,8 @@ class ModelSystem:
                     self._distribute_sec_dests(
                         purpose, "car", purpose_impedance)
             else:
-                demand = purpose.calc_demand()
+                if purpose.name != "wh":
+                    demand = purpose.calc_demand()
                 if purpose.dest != "source":
                     for mode in demand:
                         self.dtm.add_demand(demand[mode])
@@ -505,7 +507,8 @@ class AgentModelSystem(ModelSystem):
                     purpose.init_sums()
                     purpose.calc_basic_prob(purpose_impedance)
                 if is_last_iteration and purpose.dest != "source":
-                    purpose.access_model.calc_accessibility(purpose_impedance)
+                    purpose.accessibility_model.calc_accessibility(
+                        purpose_impedance)
         tour_probs = self.dm.generate_tour_probs()
         log.info("Assigning mode and destination for {} agents ({} % of total population)".format(
             len(self.dm.population), int(zone_param.agent_demand_fraction*100)))

--- a/Scripts/modelsystem.py
+++ b/Scripts/modelsystem.py
@@ -334,13 +334,18 @@ class ModelSystem:
 
     def _calculate_savu_zones(self):
         sust_logsum = 0
+        car_logsum = 0
         for purpose in self.dm.tour_purposes:
             if (purpose.area == "metropolitan" and purpose.orig == "home"
                     and purpose.dest != "source"
                     and not isinstance(purpose, SecDestPurpose)):
                 zone_numbers = purpose.zone_numbers
                 weight = gen_param.tour_generation[purpose.name]["population"]
-                sust_logsum += weight * purpose.sustainable_accessibility
+                sust_logsum += weight * purpose.sustainable_access
+                car_logsum += weight * purpose.car_access
+        self.resultdata.print_data(
+            sust_logsum, "sustainable_accessibility.txt", "all")
+        self.resultdata.print_data(car_logsum, "car_accessibility.txt", "all")
         savu = numpy.searchsorted(zone_param.savu_intervals, sust_logsum) + 1
         self.resultdata.print_data(
             pandas.Series(savu, zone_numbers), "savu.txt", "savu_zone")

--- a/Scripts/modelsystem.py
+++ b/Scripts/modelsystem.py
@@ -112,7 +112,7 @@ class ModelSystem:
                     purpose, previous_iter_impedance)
                 purpose.calc_prob(purpose_impedance)
                 if is_last_iteration and purpose.dest != "source":
-                    purpose.access_model.calc_basic_prob(purpose_impedance)
+                    purpose.access_model.calc_accessibility(purpose_impedance)
         
         # Tour generation
         self.dm.generate_tours()
@@ -505,7 +505,7 @@ class AgentModelSystem(ModelSystem):
                     purpose.init_sums()
                     purpose.calc_basic_prob(purpose_impedance)
                 if is_last_iteration and purpose.dest != "source":
-                    purpose.access_model.calc_basic_prob(purpose_impedance)
+                    purpose.access_model.calc_accessibility(purpose_impedance)
         tour_probs = self.dm.generate_tour_probs()
         log.info("Assigning mode and destination for {} agents ({} % of total population)".format(
             len(self.dm.population), int(zone_param.agent_demand_fraction*100)))


### PR DESCRIPTION
Refactor accessibility calculations and printing to new sub-class `AccessibilityModel(ModeDestModel)`. The benefits are:
- Accessibility calculations do not clutter demand model calculations
- Separate parameters for capital region and surrounding municipalities can be ignored in accessibility calculations

Also add printing of all-purposes-combined sustainable and car accessibility.