### PR TITLE
Print number of person trips per area

### DIFF
--- a/Scripts/modelsystem.py
+++ b/Scripts/modelsystem.py
@@ -272,20 +272,25 @@ class ModelSystem:
             self.dtm.add_demand(ext_demand)
 
         # Calculate tour sums and mode shares
-        trip_sum = {mode: self._sum_trips_per_zone(mode, include_dests=False)
+        tour_sum = {mode: self._sum_trips_per_zone(mode, include_dests=False)
             for mode in self.travel_modes}
-        sum_all = sum(trip_sum.values())
+        sum_all = sum(tour_sum.values())
         mode_shares = {}
         ar = ArrayAggregator(sum_all.index)
-        for mode in trip_sum:
+        for mode in tour_sum:
             self.resultdata.print_data(
-                trip_sum[mode], "origins_demand.txt", mode)
+                tour_sum[mode], "origins_demand.txt", mode)
             self.resultdata.print_data(
-                ar.aggregate(trip_sum[mode]), "origin_demand_areas.txt", mode)
+                ar.aggregate(tour_sum[mode]), "origin_demand_areas.txt", mode)
             self.resultdata.print_data(
-                trip_sum[mode] / sum_all, "origins_shares.txt", mode)
-            mode_shares[mode] = trip_sum[mode].sum() / sum_all.sum()
+                tour_sum[mode] / sum_all, "origins_shares.txt", mode)
+            mode_shares[mode] = tour_sum[mode].sum() / sum_all.sum()
         self.mode_share.append(mode_shares)
+        trip_sum = {mode: self._sum_trips_per_zone(mode)
+            for mode in self.travel_modes}
+        for mode in tour_sum:
+            self.resultdata.print_data(
+                ar.aggregate(trip_sum[mode]), "trips_areas.txt", mode)
 
         # Add vans and save demand matrices
         for ap in self.ass_model.assignment_periods:


### PR DESCRIPTION
A trip is connected to the area where it starts,
hence an A->B tour typically produces one trip starting in A
and one trip starting in B. Accordingly secondary destinations
also produce one trip starting in the area of the sec. dest.

External trips are not included.

Closes #319.