### PR TITLE
Network validation

### DIFF
--- a/Scripts/assignment/assignment_period.py
+++ b/Scripts/assignment/assignment_period.py
@@ -190,17 +190,7 @@ class AssignmentPeriod(Period):
         self._calc_boarding_penalties(5)
         has_visited = {}
         network = self.emme_scenario.get_network()
-        transit_zones = set()
-        for node in network.nodes():
-            transit_zones.add(node.label)
-        # check that fare zones exist in network
-        log.debug("Network has fare zones {}".format(', '.join(transit_zones)))
-        zones_in_zonedata = set(char for char in ''.join(fares["fare"].keys()))
-        log.debug("Zonedata has fare zones {}".format(', '.join(zones_in_zonedata)))
-        if zones_in_zonedata > transit_zones:
-            log.warn("All zones in transit costs do not exist in Emme-network labels.")
-        if transit_zones > zones_in_zonedata:
-            log.warn("All Emme-node labels do not have transit costs specified.")
+        transit_zones = {node.label for node in network.nodes()}
         tc = "transit_work"
         spec = TransitSpecification(
             self._segment_results[tc], self.extra("hw"),

--- a/Scripts/assignment/emme_assignment.py
+++ b/Scripts/assignment/emme_assignment.py
@@ -356,6 +356,9 @@ class EmmeAssignmentModel(AssignmentModel):
             "TRANSIT_SEGMENT", param.extra_waiting_time["penalty"],
             "wait time st.dev.", overwrite=True, scenario=scenario)
         self.emme_project.create_extra_attribute(
+            "TRANSIT_SEGMENT", "@" + param.congestion_cost,
+            "transit congestion cost", overwrite=True, scenario=scenario)
+        self.emme_project.create_extra_attribute(
             "TRANSIT_SEGMENT", "@" + param.uncongested_transit_time,
             "uncongested transit time", overwrite=True, scenario=scenario)
         self.emme_project.create_extra_attribute(

--- a/Scripts/assignment/emme_bindings/emme_project.py
+++ b/Scripts/assignment/emme_bindings/emme_project.py
@@ -21,10 +21,7 @@ class EmmeProject:
     def __init__(self, project_path, emmebank_path=None):
         log.info("Starting Emme...")
         emme_desktop = _app.start_dedicated(
-            project=project_path,
-            visible=False, 
-            user_initials="HSL"
-        )
+            project=project_path, visible=False, user_initials="HSL")
         if emmebank_path is not None:
             db = emme_desktop.data_explorer().add_database(emmebank_path)
             db.open()

--- a/Scripts/helmet_network_validation.py
+++ b/Scripts/helmet_network_validation.py
@@ -1,0 +1,46 @@
+import os
+import sys
+import logging
+from collections import namedtuple
+
+import inro.modeller as _m
+
+# TODO Could this be done more elegantly?
+sys.path.append(os.path.dirname(os.path.realpath(__file__)))
+from utils.validate_network import validate
+
+
+class Validation(_m.Tool()):
+    def __init__(self):
+        """Tool with click-button that can be imported in the Modeller GUI.
+        """
+        self.tool_run_msg = ""
+        sh = logging.StreamHandler(stream=self)
+        logging.getLogger().addHandler(sh)
+
+    def page(self):
+        pb = _m.ToolPageBuilder(self)
+        pb.title = "Validate network"
+        if self.tool_run_msg:
+            pb.add_html(self.tool_run_msg)
+        return pb.render()
+
+    def run(self):
+        self()
+
+    def __call__(self):
+        """Perform a network validation for current scenario.
+        """
+        modeller = _m.Modeller()
+        scen = modeller.scenario
+        validate(scen.get_network())
+        msg = "Network validation finished for scenario {}!".format(scen.id)
+        self.write(msg)
+        self.tool_run_msg = _m.PageBuilder.format_info(msg)
+
+    def write(self, message):
+        _m.logbook_write(message)
+
+    def flush(self):
+        """Flush the logbook (i.e., do nothing)."""
+        pass

--- a/Scripts/helmet_validate_inputfiles.py
+++ b/Scripts/helmet_validate_inputfiles.py
@@ -163,6 +163,19 @@ def main(args):
                     scen.id)
                 log.error(msg)
                 raise ValueError(msg)
+            attrs = (
+                "@pyoratieluokka",
+                "@hinta_aht",
+                "@hinta_pt",
+                "@hinta_iht",
+                "@hw_aht",
+                "@hw_pt",
+                "@hw_iht",
+            )
+            for attr in attrs:
+                if scen.extra_attribute(attr) is None:
+                    msg = "Extra attribute {} missing from scenario {}".format(
+                        attr, scen.id)
             validate(scen.get_network(), forecast_zonedata.transit_zone)
             app.close()
 

--- a/Scripts/helmet_validate_inputfiles.py
+++ b/Scripts/helmet_validate_inputfiles.py
@@ -93,6 +93,14 @@ def main(args):
     for i, emp_path in enumerate(emme_paths):
         log.info("Checking input data for scenario #{} ...".format(i))
 
+        # Check forecasted zonedata
+        if not os.path.exists(forecast_zonedata_paths[i]):
+            msg = "Forecast data directory '{}' does not exist.".format(
+                forecast_zonedata_paths[i])
+            log.error(msg)
+            raise ValueError(msg)
+        forecast_zonedata = ZoneData(forecast_zonedata_paths[i], zone_numbers)
+
         # Check network
         if not args.do_not_use_emme:
             if not os.path.isfile(emp_path):
@@ -143,16 +151,8 @@ def main(args):
                     scen.id)
                 log.error(msg)
                 raise ValueError(msg)
-            validate(scen.get_network())
+            validate(scen.get_network(), forecast_zonedata.fares)
             app.close()
-
-        # Check forecasted zonedata
-        if not os.path.exists(forecast_zonedata_paths[i]):
-            msg = "Forecast data directory '{}' does not exist.".format(
-                forecast_zonedata_paths[i])
-            log.error(msg)
-            raise ValueError(msg)
-        forecast_zonedata = ZoneData(forecast_zonedata_paths[i], zone_numbers)
 
     log.info("Successfully validated all input files")
 

--- a/Scripts/helmet_validate_inputfiles.py
+++ b/Scripts/helmet_validate_inputfiles.py
@@ -67,17 +67,24 @@ def main(args):
         assignment_model = MockAssignmentModel(MatrixData(mock_result_path))
         zone_numbers = assignment_model.zone_numbers
     else:
-        if not os.path.isfile(emme_paths[0]):
+        emp_path = emme_paths[0]
+        if not os.path.isfile(emp_path):
             msg = ".emp project file not found in given '{}' location.".format(
-                emme_paths[0])
+                emp_path)
             log.error(msg)
             raise ValueError(msg)
         import inro.emme.desktop.app as _app
         app = _app.start_dedicated(
-            project=emme_paths[0], visible=False, user_initials="HSL")
-        zone_numbers = numpy.array(
-            app.data_explorer().active_database().core_emmebank.scenario(
-                first_scenario_ids[0]).zone_numbers)
+            project=emp_path, visible=False, user_initials="HSL")
+        scen_id = first_scenario_ids[0]
+        try:
+            zone_numbers = numpy.array(
+                app.data_explorer().active_database().core_emmebank.scenario(
+                    scen_id).zone_numbers)
+        except AttributeError:
+            msg = "Project {} has no scenario {}".format(emp_path, scen_id)
+            log.error(msg)
+            raise ValueError(msg)
         app.close()
     # Check base zonedata
     base_zonedata = ZoneData(base_zonedata_path, zone_numbers)
@@ -109,7 +116,7 @@ def main(args):
                 log.error(msg)
                 raise ValueError(msg)
             app = _app.start_dedicated(
-                project=emme_paths[0], visible=False, user_initials="HSL")
+                project=emp_path, visible=False, user_initials="HSL")
             emmebank = app.data_explorer().active_database().core_emmebank
             nr_attr = {
                 # Number of existing extra attributes

--- a/Scripts/helmet_validate_inputfiles.py
+++ b/Scripts/helmet_validate_inputfiles.py
@@ -151,7 +151,7 @@ def main(args):
                     scen.id)
                 log.error(msg)
                 raise ValueError(msg)
-            validate(scen.get_network(), forecast_zonedata.fares)
+            validate(scen.get_network(), forecast_zonedata.transit_zone)
             app.close()
 
     log.info("Successfully validated all input files")

--- a/Scripts/helmet_validate_inputfiles.py
+++ b/Scripts/helmet_validate_inputfiles.py
@@ -4,6 +4,7 @@ import numpy
 
 from utils.config import Config
 import utils.log as log
+from utils.validate_network import validate
 from assignment.emme_assignment import EmmeAssignmentModel
 from assignment.mock_assignment import MockAssignmentModel
 from datahandling.matrixdata import MatrixData
@@ -101,11 +102,16 @@ def main(args):
                 raise ValueError(msg)
             app = _app.start_dedicated(
                 project=emme_paths[0], visible=False, user_initials="HSL")
-            scen = app.data_explorer().active_database().core_emmebank.scenario(
-                first_scenario_ids[i])
-            network = scen.get_network()
-            # TODO Validate network
-            scen.publish_network(network)
+            emmebank = app.data_explorer().active_database().core_emmebank
+            dimensions = emmebank.dimensions
+            # TODO Check extra attribute dimensions
+            scen = emmebank.scenario(first_scenario_ids[i])
+            if (numpy.array(scen.zone_numbers) != zone_numbers).any():
+                msg = "Zone numbers do not match for EMME scenario {}".format(
+                    scen.id)
+                log.error(msg)
+                raise ValueError(msg)
+            validate(scen.get_network())
             app.close()
 
         # Check forecasted zonedata

--- a/Scripts/parameters/assignment.py
+++ b/Scripts/parameters/assignment.py
@@ -443,6 +443,7 @@ segment_results = {
     "transfer_boardings": "trb",
 }
 # Hard-coded in Emme congested transit assignment
+congestion_cost = "ccost"
 uncongested_transit_time = "base_timtr"
 # Emme matrix IDs
 emme_demand_mtx = {

--- a/Scripts/tests/unit/test_assignment.py
+++ b/Scripts/tests/unit/test_assignment.py
@@ -4,6 +4,7 @@ import unittest
 import numpy
 import os
 
+from utils.validate_network import validate
 from assignment.emme_bindings.mock_project import MockProject
 from assignment.emme_assignment import EmmeAssignmentModel
 from datahandling.resultdata import ResultsData
@@ -17,9 +18,6 @@ class EmmeAssignmentTest(unittest.TestCase):
             "..", "test_data", "Network")
         scenario_id = 19
         context.import_scenario(scenario_dir, scenario_id, "test")
-        ass_model = EmmeAssignmentModel(
-            context, scenario_id, save_matrices=True)
-        ass_model.prepare_network()
         fares = {
             "fare": {
                 'A': 59,
@@ -28,6 +26,12 @@ class EmmeAssignmentTest(unittest.TestCase):
             "dist_fare": 3.0,
             "start_fare": 35,
         }
+        validate(
+            context.modeller.emmebank.scenario(scenario_id).get_network(),
+            fares)
+        ass_model = EmmeAssignmentModel(
+            context, scenario_id, save_matrices=True)
+        ass_model.prepare_network()
         peripheral_cost = numpy.arange(10).reshape((1, 10))
         ass_model.calc_transit_cost(fares, peripheral_cost)
         nr_zones = ass_model.nr_zones

--- a/Scripts/tests/unit/test_assignment.py
+++ b/Scripts/tests/unit/test_assignment.py
@@ -20,7 +20,8 @@ class EmmeAssignmentTest(unittest.TestCase):
         context.import_scenario(scenario_dir, scenario_id, "test")
         fares = {
             "fare": {
-                'A': 59,
+                "A": 59,
+                "AB": 109,
             },
             "exclusive": {},
             "dist_fare": 3.0,

--- a/Scripts/utils/validate_network.py
+++ b/Scripts/utils/validate_network.py
@@ -33,7 +33,7 @@ def validate(network, fares=None):
         log.debug("Network has fare zones {}".format(', '.join(transit_zones)))
         if fare_zones > transit_zones:
             log.warn(
-                "All zones in transit costs do not exist in node labels.")
+                "Some zones in transit costs do not exist in node labels.")
         found_zone_share = nr_transit_zone_nodes / nr_nodes
         if found_zone_share < 0.5:
             msg = "Found transit fare zone for only {:.0%} of nodes.".format(

--- a/Scripts/utils/validate_network.py
+++ b/Scripts/utils/validate_network.py
@@ -15,17 +15,11 @@ def validate(network, fares=None):
     ----------
     network : inro.emme.network.Network
         Network to be validated
-    fares : dict (optional)
-            key : str
-                Fare type (fare/exclusive/dist_fare/start_fare)
-            value : dict
-                key : str
-                    Zone combination (AB/ABC/...)
-                value : float/str
-                    Transit fare or name of municipality
+    fares : assignment.datatypes.transit_fare.TransitFareZoneSpecification
+            Transit fare zone specification (optional)
     """
     if fares is not None:
-        fare_zones = {char for char in ''.join(fares["fare"])}
+        fare_zones = fares.transit_fare_zones()
         log.debug("Zonedata has fare zones {}".format(', '.join(fare_zones)))
         transit_zones = set()
         nr_transit_zone_nodes = 0

--- a/Scripts/utils/validate_network.py
+++ b/Scripts/utils/validate_network.py
@@ -2,27 +2,29 @@ import utils.log as log
 import parameters.assignment as param
 
 
-def validate(network, fares):
-    fare_zones = {char for char in ''.join(fares["fare"])}
-    log.debug("Zonedata has fare zones {}".format(', '.join(fare_zones)))
-    transit_zones = set()
-    nr_transit_zone_nodes = 0
-    nr_nodes = 0
-    # check that fare zones exist in network
-    for node in network.nodes():
-        nr_nodes += 1
-        if node.label in fare_zones:
-            nr_transit_zone_nodes += 1
-        transit_zones.add(node.label)
-    log.debug("Network has fare zones {}".format(', '.join(transit_zones)))
-    if fare_zones > transit_zones:
-        log.warn(
-            "All zones in transit costs do not exist in Emme-network labels.")
-    found_zone_share = nr_transit_zone_nodes / nr_nodes
-    if found_zone_share < 0.5:
-        msg = "Found transit fare zone for only {:.0%} of nodes.".format(
-            found_zone_share)
-        log.error(msg)
+def validate(network, fares=None):
+    if fares is not None:
+        fare_zones = {char for char in ''.join(fares["fare"])}
+        log.debug("Zonedata has fare zones {}".format(', '.join(fare_zones)))
+        transit_zones = set()
+        nr_transit_zone_nodes = 0
+        nr_nodes = 0
+        # check that fare zones exist in network
+        for node in network.nodes():
+            nr_nodes += 1
+            if node.label in fare_zones:
+                nr_transit_zone_nodes += 1
+            transit_zones.add(node.label)
+        log.debug("Network has fare zones {}".format(', '.join(transit_zones)))
+        if fare_zones > transit_zones:
+            log.warn(
+                "All zones in transit costs do not exist in node labels.")
+        found_zone_share = nr_transit_zone_nodes / nr_nodes
+        if found_zone_share < 0.5:
+            msg = "Found transit fare zone for only {:.0%} of nodes.".format(
+                found_zone_share)
+            log.error(msg)
+            raise ValueError(msg)
     for link in network.links():
         if network.mode('c') in link.modes:
             linktype = link.type % 100
@@ -31,8 +33,23 @@ def validate(network, fares):
                     and linktype not in param.connector_link_types):
                 msg = "Link type missing for link {}".format(link.id)
                 log.error(msg)
+                raise ValueError(msg)
+        if network.mode('t') in link.modes:
+            speedstr = str(int(link.data1))
+            speed = {
+                "aht": int(speedstr[:-4]),
+                "pt": int(speedstr[-4:-2]),
+                "iht": int(speedstr[-2:]),
+            }
+            for tp in speed:
+                if speed[tp] == 0:
+                    msg = "Speed is zero for time period {} on link {}".format(
+                        tp, link.id)
+                    log.error(msg)
+                    raise ValueError(msg)
     for line in network.transit_lines():
         for hdwy in ("@hw_aht", "@hw_pt", "@hw_iht"):
             if line[hdwy] < 0.02:
                 msg = "Headway missing for line {}".format(line.id)
                 log.error(msg)
+                raise ValueError(msg)

--- a/Scripts/utils/validate_network.py
+++ b/Scripts/utils/validate_network.py
@@ -19,7 +19,7 @@ def validate(network, fares=None):
             Transit fare zone specification (optional)
     """
     if fares is not None:
-        fare_zones = fares.transit_fare_zones()
+        fare_zones = fares.transit_fare_zones
         log.debug("Zonedata has fare zones {}".format(', '.join(fare_zones)))
         transit_zones = set()
         nr_transit_zone_nodes = 0

--- a/Scripts/utils/validate_network.py
+++ b/Scripts/utils/validate_network.py
@@ -3,6 +3,27 @@ import parameters.assignment as param
 
 
 def validate(network, fares=None):
+    """Validate EMME network in terms of HELMET compatibility.
+
+    Check that:
+    - all auto links have volume-delay functions defined
+    - all tram links have speed defined
+    - all transit lines have headways defined
+    - a majority of nodes has transit fare zone defined (optional)
+
+    Parameters
+    ----------
+    network : inro.emme.network.Network
+        Network to be validated
+    fares : dict (optional)
+            key : str
+                Fare type (fare/exclusive/dist_fare/start_fare)
+            value : dict
+                key : str
+                    Zone combination (AB/ABC/...)
+                value : float/str
+                    Transit fare or name of municipality
+    """
     if fares is not None:
         fare_zones = {char for char in ''.join(fares["fare"])}
         log.debug("Zonedata has fare zones {}".format(', '.join(fare_zones)))

--- a/Scripts/utils/validate_network.py
+++ b/Scripts/utils/validate_network.py
@@ -1,0 +1,38 @@
+import utils.log as log
+import parameters.assignment as param
+
+
+def validate(network, fares):
+    fare_zones = {char for char in ''.join(fares["fare"])}
+    log.debug("Zonedata has fare zones {}".format(', '.join(fare_zones)))
+    transit_zones = set()
+    nr_transit_zone_nodes = 0
+    nr_nodes = 0
+    # check that fare zones exist in network
+    for node in network.nodes():
+        nr_nodes += 1
+        if node.label in fare_zones:
+            nr_transit_zone_nodes += 1
+        transit_zones.add(node.label)
+    log.debug("Network has fare zones {}".format(', '.join(transit_zones)))
+    if fare_zones > transit_zones:
+        log.warn(
+            "All zones in transit costs do not exist in Emme-network labels.")
+    found_zone_share = nr_transit_zone_nodes / nr_nodes
+    if found_zone_share < 0.5:
+        msg = "Found transit fare zone for only {:.0%} of nodes.".format(
+            found_zone_share)
+        log.error(msg)
+    for link in network.links():
+        if network.mode('c') in link.modes:
+            linktype = link.type % 100
+            if (linktype not in param.roadclasses
+                    and linktype not in param.custom_roadtypes
+                    and linktype not in param.connector_link_types):
+                msg = "Link type missing for link {}".format(link.id)
+                log.error(msg)
+    for line in network.transit_lines():
+        for hdwy in ("@hw_aht", "@hw_pt", "@hw_iht"):
+            if line[hdwy] < 0.02:
+                msg = "Headway missing for line {}".format(line.id)
+                log.error(msg)


### PR DESCRIPTION
Adds EMME network validation in terms of HELMET compatibility. This can be run standalone through the Modeller GUI (see #337) or as part of `helmet_validate_inputfiles.py`. Checks that:
- all auto links have volume-delay functions defined
- all tram links have speed defined
- all transit lines have headways defined
- a majority of nodes has transit fare zone defined (optional)

Moreover, adds check that there is space for extra attributes in database to `helmet_validate_inputfiles.py`.

To be able to check several networks in `helmet_validate_inputfiles.py` (potentially located in different EMME databases), `EmmeProject` dependency needed to be removed from `helmet_validate_inputfiles.py`, because `EmmeProject` starts a Modeller session. Only one Modeller session can be started in each python session. Therefore the databases containing the networks are now referenced directly in `helmet_validate_inputfiles.py`.