### PR TITLE
Move car distance cost setting to `prepare_network()`

### DIFF
--- a/Scripts/assignment/abstract_assignment.py
+++ b/Scripts/assignment/abstract_assignment.py
@@ -30,7 +30,7 @@ class AssignmentModel:
         pass
 
     @abstractmethod
-    def prepare_network(self):
+    def prepare_network(self, car_dist_unit_cost=None):
         pass
 
     @abstractmethod

--- a/Scripts/assignment/emme_assignment.py
+++ b/Scripts/assignment/emme_assignment.py
@@ -41,7 +41,7 @@ class EmmeAssignmentModel(AssignmentModel):
         self.mod_scenario = self.emme_project.modeller.emmebank.scenario(
             first_scenario_id)
 
-    def prepare_network(self):
+    def prepare_network(self, car_dist_unit_cost=None):
         """Create matrices, extra attributes and calc background variables."""
         self._add_bus_stops()
         if self.save_matrices:
@@ -90,6 +90,7 @@ class EmmeAssignmentModel(AssignmentModel):
                 break
         self._create_attributes(self.day_scenario, self._extra)
         for ap in self.assignment_periods:
+            ap.dist_unit_cost = car_dist_unit_cost
             ap.prepare(self._create_attributes(ap.emme_scenario, ap.extra))
         for idx in param.volume_delay_funcs:
             try:

--- a/Scripts/assignment/emme_assignment.py
+++ b/Scripts/assignment/emme_assignment.py
@@ -90,7 +90,8 @@ class EmmeAssignmentModel(AssignmentModel):
                 break
         self._create_attributes(self.day_scenario, self._extra)
         for ap in self.assignment_periods:
-            ap.dist_unit_cost = car_dist_unit_cost
+            if car_dist_unit_cost is not None:
+                ap.dist_unit_cost = car_dist_unit_cost
             ap.prepare(self._create_attributes(ap.emme_scenario, ap.extra))
         for idx in param.volume_delay_funcs:
             try:

--- a/Scripts/assignment/mock_assignment.py
+++ b/Scripts/assignment/mock_assignment.py
@@ -43,7 +43,7 @@ class MockAssignmentModel(AssignmentModel):
     def calc_noise(self):
         return pandas.Series(0, zone_param.area_aggregation)
 
-    def prepare_network(self):
+    def prepare_network(self, car_dist_unit_cost=None):
         pass
 
     def init_assign(self, demand):

--- a/Scripts/modelsystem.py
+++ b/Scripts/modelsystem.py
@@ -57,10 +57,6 @@ class ModelSystem:
         self.zdata_forecast = ZoneData(
             zone_data_path, self.zone_numbers)
 
-        # Set dist unit cost from zonedata
-        for ap in self.ass_model.assignment_periods:
-            ap.dist_unit_cost = self.zdata_forecast.car_dist_cost
-
         # Output data
         self.resultmatrices = MatrixData(
             os.path.join(results_path, name, "Matrices"))
@@ -170,7 +166,7 @@ class ModelSystem:
         impedance = {}
 
         # create attributes and background variables to network
-        self.ass_model.prepare_network()
+        self.ass_model.prepare_network(self.zdata_forecast.car_dist_cost)
 
         # Calculate transit cost matrix, and save it to emmebank
         with self.basematrices.open("demand", "aht", self.ass_model.zone_numbers) as mtx:


### PR DESCRIPTION
Fixes #341. In olusanya, assignment periods are not created until `prepare_network()` so setting car distance cost must be done there, but before `ap.prepare()` because in that method, link costs are calculated.