### PR TITLE
Fix `WindowsError`

### DIFF
--- a/Scripts/dev-config.json
+++ b/Scripts/dev-config.json
@@ -1,5 +1,5 @@
 {
-    "HELMET_VERSION": "v4.0.5",
+    "HELMET_VERSION": "v4.0.6",
     "LOG_LEVEL": "INFO",
     "LOG_FORMAT": "TEXT",
     "RUN_AGENT_SIMULATION": false,

--- a/Scripts/utils/config.py
+++ b/Scripts/utils/config.py
@@ -36,7 +36,7 @@ class Config:
         try:
             # If model system is in a git repo
             return subprocess.check_output(["git", "describe", "--tags"])
-        except subprocess.CalledProcessError:
+        except (subprocess.CalledProcessError, WindowsError):
             # If model system is downloaded with helmet-ui
             return self.__get_value("HELMET_VERSION")
 


### PR DESCRIPTION
`subprocess.CalledProcessError` only works if git client is installed. For other users, helmet will crash. @johpiip could you merge and make a new release v4.0.6?