### PR TITLE
Add car ownership sensitivity analyses

### DIFF
--- a/Scripts/assignment/assignment_period.py
+++ b/Scripts/assignment/assignment_period.py
@@ -257,12 +257,17 @@ class AssignmentPeriod(Period):
         segres = self._segment_results
         for tc in segres:
             for res in segres[tc]:
-                nodeattr = self.extra(tc[:10]+"n_"+param.segment_results[res])
-                for segment in network.transit_segments():
-                    if res == "transit_volumes":
+                if res == "transit_volumes":
+                    for link in network.links():
+                        link[self.extra(tc)] = 0
+                    for segment in network.transit_segments():
                         if segment.link is not None:
                             segment.link[self.extra(tc)] += segment[segres[tc][res]]
-                    else:
+                else:
+                    nodeattr = self.extra(tc[:10]+"n_"+param.segment_results[res])
+                    for node in network.nodes():
+                        node[nodeattr] = 0
+                    for segment in network.transit_segments():
                         segment.i_node[nodeattr] += segment[segres[tc][res]]
         self.emme_scenario.publish_network(network)
 

--- a/Scripts/assignment/emme_assignment.py
+++ b/Scripts/assignment/emme_assignment.py
@@ -44,7 +44,7 @@ class EmmeAssignmentModel(AssignmentModel):
 
     def prepare_network(self, car_dist_unit_cost=None):
         """Create matrices, extra attributes and calc background variables."""
-        if network_is_prepared:
+        if self.network_is_prepared:
             return
         self._add_bus_stops()
         if self.save_matrices:

--- a/Scripts/assignment/emme_assignment.py
+++ b/Scripts/assignment/emme_assignment.py
@@ -40,9 +40,12 @@ class EmmeAssignmentModel(AssignmentModel):
         self.emme_project = emme_context
         self.mod_scenario = self.emme_project.modeller.emmebank.scenario(
             first_scenario_id)
+        self.network_is_prepared = False
 
     def prepare_network(self, car_dist_unit_cost=None):
         """Create matrices, extra attributes and calc background variables."""
+        if network_is_prepared:
+            return
         self._add_bus_stops()
         if self.save_matrices:
             self.day_scenario = self.emme_project.copy_scenario(
@@ -100,6 +103,7 @@ class EmmeAssignmentModel(AssignmentModel):
                 pass
             self.emme_project.modeller.emmebank.create_function(
                 idx, param.volume_delay_funcs[idx])
+        self.network_is_prepared = True
 
     def init_assign(self, demand):
         ap0 = self.assignment_periods[0]

--- a/Scripts/helmet.py
+++ b/Scripts/helmet.py
@@ -79,23 +79,26 @@ def main(args):
             forecast_zonedata_path, base_zonedata_path, base_matrices_path,
             results_path, ass_model, name)
 
-    # Regular model run
-    run(log_extra, model)
-
     # Run with increased car ownership
     new_name = name + "_car++"
-    model.resultdata = ResultsData(os.path.join(results_path, new_name))
-    model.resultmatrices = MatrixData(
-            os.path.join(results_path, new_name, "Matrices"))
+    model.resultdata.path = os.path.join(results_path, new_name)
+    model.resultmatrices.path = os.path.join(
+        results_path, new_name, "Matrices")
     model.cdm.set_car_growth(constant=+0.1)
     run(log_extra, model)
 
     # Run with decreased car ownership
     new_name = name + "_car--"
-    model.resultdata = ResultsData(os.path.join(results_path, new_name))
-    model.resultmatrices = MatrixData(
-            os.path.join(results_path, new_name, "Matrices"))
+    model.resultdata.path = os.path.join(results_path, new_name)
+    model.resultmatrices.path = os.path.join(
+        results_path, new_name, "Matrices")
     model.cdm.set_car_growth(factor=0.8)
+    run(log_extra, model)
+
+    # Regular model run last to save regular results in EMME
+    model.resultdata.path = os.path.join(results_path, name)
+    model.resultmatrices.path = os.path.join(results_path, name, "Matrices")
+    model.cdm.set_car_growth()
     run(log_extra, model)
 
     # delete emme strategy files for scenarios

--- a/Scripts/helmet.py
+++ b/Scripts/helmet.py
@@ -115,7 +115,7 @@ def main(args):
     log.info("Simulation ended.", extra=log_extra)
 
 def run(log_extra, model):
-    iterations = log_extra["total"]
+    iterations = log_extra["status"]["total"]
     # Run traffic assignment simulation for N iterations,
     # on last iteration model-system will save the results
     log_extra["status"]["state"] = "preparing"

--- a/Scripts/models/linear.py
+++ b/Scripts/models/linear.py
@@ -80,10 +80,24 @@ class CarDensityModel(LinearModel):
             out=numpy.array(forecast_sh_detached), where=pop_growth!=0)
         self.zone_data._values["share_detached_houses_new"] = pandas.Series(
             share_detached_new, self.zone_data.zone_numbers[self.bounds])
-    
+        self.set_car_growth()
+
+    def set_car_growth(self, constant=0.0, factor=1.0):
+        """Set extra car ownership growth for sensitivity analyses.
+
+        Parameters
+        ----------
+        constant : float (optional)
+            Constant to add to prediction
+        factor : float (optional)
+            Factor to multiply prediction by
+        """
+        self._growth_constant = constant
+        self._growth_factor = factor
+
     def predict(self):
         """Get car ownership prediction for zones.
-        
+
         Return
         ------
         pandas.Series
@@ -107,6 +121,8 @@ class CarDensityModel(LinearModel):
         base_car_density = self.zone_data_base["car_density"][self.bounds]
         prediction = (self.pop_growth_share * prediction
                       + (1-self.pop_growth_share) * base_car_density)
+        prediction += self._growth_constant
+        prediction *= self._growth_factor
         self.print_results(prediction)
         return prediction
 


### PR DESCRIPTION
Expands `helmet.py` into three different model runs (baseline, car++ and car--), which all produce separate result files

- car++ increases car density by 0.1 (100 vehicles per 1000 inhabitants) everywhere
- car-- decreases car density by 20 %