### PR TITLE
Enable workforce accessibility calculation and printing

### DIFF
--- a/Scripts/modelsystem.py
+++ b/Scripts/modelsystem.py
@@ -110,7 +110,7 @@ class ModelSystem:
                 purpose_impedance = self.imptrans.transform(
                     purpose, previous_iter_impedance)
                 purpose.calc_prob(purpose_impedance)
-                if is_last_iteration and purpose.dest != "source":
+                if is_last_iteration and purpose.name not in ("sop", "so"):
                     purpose.accessibility_model.calc_accessibility(
                         purpose_impedance)
         


### PR DESCRIPTION
The "sop" (as well as the no longer existant "so") model has no `AccessibilityModel`, so the accessibility calculation needs to be disabled for it. By accident, I had disabled it for workforce accessibility `Purpose` as well. This PR fixes the problem. 

However, with the `AccessibilityModel` refactoring done, workforce accessibility calculation could maybe be made more streamlined with an own subclass. 