### PR TITLE
Remove transit passengers and bikes from vehicle kms

### DIFF
--- a/Scripts/assignment/emme_assignment.py
+++ b/Scripts/assignment/emme_assignment.py
@@ -166,6 +166,7 @@ class EmmeAssignmentModel(AssignmentModel):
         for linktype in param.roadtypes:
             linktypes.add(param.roadtypes[linktype])
         linklengths = pandas.Series(0.0, linktypes)
+        soft_modes = param.transit_classes + ("bike",)
         network = self.day_scenario.get_network()
         for link in network.links():
             linktype = link.type % 100
@@ -184,7 +185,9 @@ class EmmeAssignmentModel(AssignmentModel):
                     vdf_kms[ass_class][vdf] += veh_kms
                 if area in areas:
                     area_kms[ass_class][area] += veh_kms
-                if vdf in vdfs and area in vdf_area_kms[vdf]:
+                if (vdf in vdfs
+                        and area in vdf_area_kms[vdf]
+                        and ass_class not in soft_modes):
                     vdf_area_kms[vdf][area] += veh_kms
             if vdf == 0 and linktype in param.railtypes:
                 linklengths[param.railtypes[linktype]] += link.length


### PR DESCRIPTION
This PR removes transit passengers and bikes from result file `vehicle_kms_vdfs_areas.txt`. In other files, the assignment class is specified, so I left them there.