### PR TITLE
Remove 999999 replacements for time values

### DIFF
--- a/Scripts/assignment/assignment_period.py
+++ b/Scripts/assignment/assignment_period.py
@@ -134,10 +134,12 @@ class AssignmentPeriod(Period):
 
         mtxs = {imp_type: self._get_emmebank_matrices(imp_type, iteration=="last")
             for imp_type in ("time", "cost", "dist")}
-        # fix the emme path analysis results (dist and cost zero if path not found)
-        for mtx_type in mtxs:
+        # fix the emme path analysis results
+        # (dist and cost zero if path not found)
+        for mtx_type in ("cost", "dist"):
             for mtx_class in mtxs[mtx_type]:
-                mtxs[mtx_type][mtx_class][ mtxs["time"][mtx_class] > 999999 ] = 999999
+                path_not_found = mtxs["time"][mtx_class] >= 999999
+                mtxs[mtx_type][mtx_class][path_not_found] = 999999
         # adjust impedance
         mtxs["time"]["bike"] = mtxs["time"]["bike"].clip(None, 9999.)
         for ass_class in ("car_work", "car_leisure"):

--- a/Scripts/assignment/assignment_period.py
+++ b/Scripts/assignment/assignment_period.py
@@ -138,7 +138,7 @@ class AssignmentPeriod(Period):
         # (dist and cost zero if path not found)
         for mtx_type in ("cost", "dist"):
             for mtx_class in mtxs[mtx_type]:
-                path_not_found = mtxs["time"][mtx_class] >= 999999
+                path_not_found = mtxs["time"][mtx_class] > 999999
                 mtxs[mtx_type][mtx_class][path_not_found] = 999999
         # adjust impedance
         mtxs["time"]["bike"] = mtxs["time"]["bike"].clip(None, 9999.)


### PR DESCRIPTION
The code has looped through all OD-impedances (including travel time) and replaced them by 999999 if travel time is greater than 999999 (i.e., no path was found). In python 2.7 this worked fine, because travel time was usually last in the dict, so that replacement happened last. In python 3.7 however, travel time is usually first in the dict (because it was inserted first), so when handling the other impedances, travel time would no longer be greater than 999999!

I see not reason to replace travel time by 999999, as it will be a very large number anyway.