### PR TITLE
Convergence indicators

### DIFF
--- a/Scripts/assignment/departure_time.py
+++ b/Scripts/assignment/departure_time.py
@@ -24,8 +24,19 @@ class DepartureTimeModel:
     def init_demand(self):
         """Initialize/reset demand for all time periods.
 
-        Includes all transport_classes, each being set to zero.
+        Includes all transport classes, each being set to zero.
+        The function also calculates two demand convergence indicators,
+        comparing car work demand matrix from previous round to current one.
+
+        Returns
+        -------
+        dict
+            rel_gap : float
+                Mean relative gap for car work demand ((new-old)/old)
+            max_gap : float
+                Maximum gap for OD pair in car work demand matrix
         """
+        # Calculate gaps
         try:
             car_demand = self.demand["aht"]["car_work"]
         except TypeError:
@@ -37,11 +48,14 @@ class DepartureTimeModel:
         except AttributeError:
             relative_gap = 0
         self.old_car_demand = car_demand
+
+        # Init demand
         n = self.nr_zones
         self.demand = {tp: {tc: numpy.zeros((n, n))
                 for tc in transport_classes}
             for tp in self.time_periods}
-        return relative_gap, max_gap
+
+        return {"rel_gap": relative_gap, "max_gap": max_gap}
 
     def add_demand(self, demand):
         """Add demand matrix for whole day.

--- a/Scripts/assignment/departure_time.py
+++ b/Scripts/assignment/departure_time.py
@@ -17,6 +17,8 @@ class DepartureTimeModel:
     def __init__(self, nr_zones):
         self.nr_zones = nr_zones
         self.time_periods = list(param.backup_demand_share)
+        self.demand = None
+        self.old_car_demand = 0
         self.init_demand()
 
     def init_demand(self):
@@ -24,10 +26,22 @@ class DepartureTimeModel:
 
         Includes all transport_classes, each being set to zero.
         """
+        try:
+            car_demand = self.demand["aht"]["car_work"]
+        except TypeError:
+            car_demand = 0
+        max_gap = numpy.abs(car_demand - self.old_car_demand).max()
+        try:
+            old_sum = self.old_car_demand.sum()
+            relative_gap = (car_demand.sum()-old_sum) / old_sum
+        except AttributeError:
+            relative_gap = 0
+        self.old_car_demand = car_demand
         n = self.nr_zones
         self.demand = {tp: {tc: numpy.zeros((n, n))
                 for tc in transport_classes}
             for tp in self.time_periods}
+        return relative_gap, max_gap
 
     def add_demand(self, demand):
         """Add demand matrix for whole day.

--- a/Scripts/modelsystem.py
+++ b/Scripts/modelsystem.py
@@ -73,6 +73,7 @@ class ModelSystem:
         self.cdm = CarDensityModel(
             self.zdata_base, self.zdata_forecast, bounds, self.resultdata)
         self.mode_share = []
+        self.convergence = []
         self.trucks = self.fm.calc_freight_traffic("truck")
         self.trailer_trucks = self.fm.calc_freight_traffic("trailer_truck")
 
@@ -311,7 +312,11 @@ class ModelSystem:
             self._calculate_accessibility_and_savu_zones()
 
         # Reset time-period specific demand matrices (DTM), and empty result buffer
-        self.dtm.init_demand()
+        self.convergence.append(self.dtm.init_demand())
+        self.resultdata.print_line("\trelative_gap\tmax_gap", "convergence")
+        for i, gap in enumerate(self.convergence):
+            self.resultdata.print_line(
+                f"{i}\t{gap[0]:0.10f}\t{gap[1]:0.10f}", "convergence")
         self.resultdata.flush()
         return impedance
 


### PR DESCRIPTION
Print two demand model convergence indicators.

The next step could be to make it possible to set a convergence threshold instead of fixed iteration number, but this requires some investigations on what the default value could be.