### PR TITLE
Insert node result aggregation into loop

### DIFF
--- a/Scripts/assignment/emme_assignment.py
+++ b/Scripts/assignment/emme_assignment.py
@@ -144,9 +144,9 @@ class EmmeAssignmentModel(AssignmentModel):
             for res in param.segment_results:
                 self._transit_segment_24h(
                     transit_class, param.segment_results[res])
-            if res != "transit_volumes":
-                self._node_24h(
-                    transit_class, param.segment_results[res])
+                if res != "transit_volumes":
+                    self._node_24h(
+                        transit_class, param.segment_results[res])
         ass_classes = list(param.emme_demand_mtx) + ["bus"]
         for ass_class in ass_classes:
             self._link_24h(ass_class)


### PR DESCRIPTION
@MerviV found that node boarding results for whole day were always zero. As it turned out, this aggregation was by accident not inside the loop iterating over result types.