### PR TITLE
Unify connector handling

### DIFF
--- a/Scripts/assignment/assignment_period.py
+++ b/Scripts/assignment/assignment_period.py
@@ -272,14 +272,12 @@ class AssignmentPeriod(Period):
         log.info("Sets car and transit functions for scenario {}".format(
             self.emme_scenario.id))
         network = self.emme_scenario.get_network()
-        l = min(param.roadclasses)
-        u = max(param.roadclasses) + 1
         transit_modesets = {modes[0]: {network.mode(m) for m in modes[1]}
             for modes in param.transit_delay_funcs}
         for link in network.links():
             # Car volume delay function definition
             linktype = link.type % 100
-            if l <= linktype < u:
+            if linktype in param.roadclasses:
                 # Car link with standard attributes
                 roadclass = param.roadclasses[linktype]
                 link.volume_delay_func = roadclass.volume_delay_func
@@ -288,14 +286,12 @@ class AssignmentPeriod(Period):
             elif linktype in param.custom_roadtypes:
                 # Custom car link
                 link.volume_delay_func = linktype - 90
-                for linktype in range(l, u):
+                for linktype in param.roadclasses:
                     roadclass = param.roadclasses[linktype]
                     if (link.volume_delay_func == roadclass.volume_delay_func
                             and link.data2 > roadclass.free_flow_speed-1):
                         # Find the most appropriate road class
                         break
-            elif linktype in param.connector_link_types:
-                link.volume_delay_func = 99
             else:
                 # Link with no car traffic
                 link.volume_delay_func = 0

--- a/Scripts/assignment/emme_assignment.py
+++ b/Scripts/assignment/emme_assignment.py
@@ -176,8 +176,6 @@ class EmmeAssignmentModel(AssignmentModel):
                 vdf = param.roadclasses[linktype].volume_delay_func
             elif linktype in param.custom_roadtypes:
                 vdf = linktype - 90
-            elif linktype in param.connector_link_types:
-                vdf = 99
             else:
                 vdf = 0
             area = belongs_to_area(link.i_node)

--- a/Scripts/parameters/assignment.py
+++ b/Scripts/parameters/assignment.py
@@ -32,6 +32,9 @@ roadclasses = {
     41: RoadClass("local", "any", 5, 600, 30, 1.000),
     42: RoadClass("local", "any", 5, 500, 23, 1.304),
 }
+connector_link_types = (84, 85, 86, 87, 88, 98, 99)
+connector = RoadClass("connector", "any", 99, 0, 0, 0)
+roadclasses.update({linktype: connector for linktype in connector_link_types})
 custom_roadtypes = {
     91: "motorway",
     92: "highway",
@@ -406,7 +409,6 @@ assignment_modes = {
     "truck": 'k',
     "van": 'v',
 }
-connector_link_types = (84, 85, 86, 87, 88, 98, 99)
 vot_classes = {
     "car_work": "work",
     "car_leisure": "leisure",

--- a/Scripts/utils/validate_network.py
+++ b/Scripts/utils/validate_network.py
@@ -44,8 +44,7 @@ def validate(network, fares=None):
         if network.mode('c') in link.modes:
             linktype = link.type % 100
             if (linktype not in param.roadclasses
-                    and linktype not in param.custom_roadtypes
-                    and linktype not in param.connector_link_types):
+                    and linktype not in param.custom_roadtypes):
                 msg = "Link type missing for link {}".format(link.id)
                 log.error(msg)
                 raise ValueError(msg)


### PR DESCRIPTION
Give connectors an own `RoadClass` so they do not have to be treated as exceptions.