### PR TITLE
Add central transit accessibility calculation

### DIFF
--- a/Scripts/models/logit.py
+++ b/Scripts/models/logit.py
@@ -464,7 +464,6 @@ class AccessibilityModel(ModeDestModel):
         except KeyError:
             # School tours do not have a constant cost parameter
             # Use value of time conversion from CBA guidelines instead
-            # TODO Calculate value
             cost_param = -0.274445953
         try:
             time_access = time_param * impedance["transit"]["time"][:, 0]
@@ -476,11 +475,12 @@ class AccessibilityModel(ModeDestModel):
         except ValueError:
             cost_access = cost_param[0] * impedance["transit"]["cost"][:, 0]
             money_utility = 1 / cost_param[0]
-        central_access = time_access + cost_access
+        central_access = pandas.Series(
+            time_access + cost_access, self.purpose.zone_numbers)
         self.resultdata.print_data(
-            pandas.Series(central_access, self.purpose.zone_numbers),
-            "central_transit_access.txt", self.purpose.name)
+            central_access, "central_transit_access.txt", self.purpose.name)
         self.purpose.central_access = money_utility * central_access
+
         mode_expsum = self._calc_utils(impedance)
 
         # Calculate sustainable and car accessibility

--- a/Scripts/models/logit.py
+++ b/Scripts/models/logit.py
@@ -457,6 +457,28 @@ class AccessibilityModel(ModeDestModel):
                 Type (time/cost/dist) : numpy 2-d matrix
                     Impedances
         """
+        # Calculate cbd transit access
+        time_param = self.dest_choice_param["transit"]["impedance"]["time"]
+        try:
+            cost_param = self.dest_choice_param["transit"]["impedance"]["cost"]
+        except KeyError:
+            # School tours do not have a constant cost parameter
+            # Use value of time conversion from CBA guidelines instead
+            # TODO Calculate value
+            cost_param = -0.1
+        try:
+            time_access = time_param * impedance["transit"]["time"][:, 0]
+        except ValueError:
+            time_access = time_param[0] * impedance["transit"]["time"][:, 0]
+        try:
+            cost_access = cost_param * impedance["transit"]["cost"][:, 0]
+        except ValueError:
+            cost_access = cost_param[0] * impedance["transit"]["cost"][:, 0]
+        central_access = time_access + cost_access
+        self.resultdata.print_data(
+            pandas.Series(central_access, self.purpose.zone_numbers),
+            "central_transit_access.txt", self.purpose.name)
+
         mode_expsum = self._calc_utils(impedance)
 
         # Calculate sustainable and car accessibility

--- a/Scripts/models/logit.py
+++ b/Scripts/models/logit.py
@@ -465,20 +465,22 @@ class AccessibilityModel(ModeDestModel):
             # School tours do not have a constant cost parameter
             # Use value of time conversion from CBA guidelines instead
             # TODO Calculate value
-            cost_param = -0.1
+            cost_param = -0.274445953
         try:
             time_access = time_param * impedance["transit"]["time"][:, 0]
         except ValueError:
             time_access = time_param[0] * impedance["transit"]["time"][:, 0]
         try:
             cost_access = cost_param * impedance["transit"]["cost"][:, 0]
+            money_utility = 1 / cost_param
         except ValueError:
             cost_access = cost_param[0] * impedance["transit"]["cost"][:, 0]
+            money_utility = 1 / cost_param[0]
         central_access = time_access + cost_access
         self.resultdata.print_data(
             pandas.Series(central_access, self.purpose.zone_numbers),
             "central_transit_access.txt", self.purpose.name)
-
+        self.purpose.central_access = money_utility * central_access
         mode_expsum = self._calc_utils(impedance)
 
         # Calculate sustainable and car accessibility

--- a/Scripts/modelsystem.py
+++ b/Scripts/modelsystem.py
@@ -360,6 +360,7 @@ class ModelSystem:
         logsum = 0
         sust_logsum = 0
         car_logsum = 0
+        central_access = 0
         for purpose in self.dm.tour_purposes:
             if (purpose.area == "metropolitan" and purpose.orig == "home"
                     and purpose.dest != "source"
@@ -370,6 +371,7 @@ class ModelSystem:
                 logsum += weight * purpose.access
                 sust_logsum += weight * purpose.sustainable_access
                 car_logsum += weight * purpose.car_access
+                central_access += weight * purpose.central_access
         pop = self.zdata_forecast["population"][bounds]
         self.resultdata.print_line(
             "\nTotal accessibility:\t{:1.2f}".format(
@@ -383,6 +385,8 @@ class ModelSystem:
         self.resultdata.print_data(
             sust_logsum, "sustainable_accessibility.txt", "all")
         self.resultdata.print_data(car_logsum, "car_accessibility.txt", "all")
+        self.resultdata.print_data(
+            central_access, "central_transit_access.txt", "all")
         savu = numpy.searchsorted(zone_param.savu_intervals, sust_logsum) + 1
         self.resultdata.print_data(
             pandas.Series(savu, zone_numbers), "savu.txt", "savu_zone")


### PR DESCRIPTION
In MALPAKKA analyses, central transit accessibility is used as an alternative accessibility indicator to standard logsum accessibility. It is the combination of travel time and cost to zone 101 (i.e., the first zone).