### PR TITLE
Hotfix/headways

### DIFF
--- a/Scripts/assignment/assignment_period.py
+++ b/Scripts/assignment/assignment_period.py
@@ -741,6 +741,11 @@ class AssignmentPeriod(Period):
     def _assign_congested_transit(self):
         """Perform congested transit assignment for one scenario."""
         log.info("Congested transit assignment started...")
+        network = self.emme_scenario.get_network()
+        headway_attr = self.extra("hw")
+        for line in network.transit_lines():
+            line.headway = line[headway_attr]
+        self.emme_scenario.publish_network(network)
         specs = self._transit_specs
         for tc in specs:
             specs[tc].transit_spec["journey_levels"][1]["boarding_cost"]["global"]["penalty"] = param.transfer_penalty[tc]

--- a/Scripts/assignment/emme_bindings/mock_project.py
+++ b/Scripts/assignment/emme_bindings/mock_project.py
@@ -309,7 +309,7 @@ class MockProject:
             "TRANSIT_SEGMENT", "@base_timtr", "", 1.0,
             overwrite=True, scenario=scenario)
         report = {
-            "stopping_criterion": "MAX_ITERATIONS",
+            "stopping_criteria": "MAX_ITERATIONS",
             "iterations": [{"number": 1}],
         }
         return report

--- a/Scripts/dev-config.json
+++ b/Scripts/dev-config.json
@@ -1,5 +1,5 @@
 {
-    "HELMET_VERSION": "v4.1.0-alpha.3",
+    "HELMET_VERSION": "v4.1.0-alpha.4",
     "LOG_LEVEL": "INFO",
     "LOG_FORMAT": "TEXT",
     "RUN_AGENT_SIMULATION": false,

--- a/Scripts/tests/unit/test_assignment.py
+++ b/Scripts/tests/unit/test_assignment.py
@@ -32,7 +32,7 @@ class EmmeAssignmentTest(unittest.TestCase):
             context.modeller.emmebank.scenario(scenario_id).get_network(),
             fares)
         ass_model = EmmeAssignmentModel(
-            context, scenario_id, save_matrices=True)
+            context, scenario_id)
         ass_model.prepare_network()
         peripheral_cost = numpy.arange(10).reshape((1, 10))
         ass_model.calc_transit_cost(fares, peripheral_cost)
@@ -49,6 +49,7 @@ class EmmeAssignmentTest(unittest.TestCase):
             "van": car_matrix,
         }
         ass_model.init_assign(demand)
+        ass_model.assignment_periods[0].assign(demand, "last")
         resultdata = ResultsData(os.path.join(
             os.path.dirname(os.path.realpath(__file__)),
             "..", "test_data", "Results", "test"))


### PR DESCRIPTION
Fix congested transit assignment by writing time-period-specific headways to `headway` attribute, because this attribute is used for calculating line capacities.