### PR TITLE
Add calculation of SAVU for population average

### DIFF
--- a/Scripts/modelsystem.py
+++ b/Scripts/modelsystem.py
@@ -376,16 +376,23 @@ class ModelSystem:
                 numpy.average(logsum, weights=pop)),
             "result_summary")
         self.resultdata.print_data(logsum, "accessibility.txt", "all")
+        ave_sust_logsum = numpy.average(sust_logsum, weights=pop)
         self.resultdata.print_line(
-            "Sustainable accessibility:\t{:1.2f}".format(
-                numpy.average(sust_logsum, weights=pop)),
+            "Sustainable accessibility:\t{:1.2f}".format(ave_sust_logsum),
             "result_summary")
         self.resultdata.print_data(
             sust_logsum, "sustainable_accessibility.txt", "all")
         self.resultdata.print_data(car_logsum, "car_accessibility.txt", "all")
-        savu = numpy.searchsorted(zone_param.savu_intervals, sust_logsum) + 1
+        intervals = zone_param.savu_intervals
+        savu = numpy.searchsorted(intervals, sust_logsum) + 1
         self.resultdata.print_data(
             pandas.Series(savu, zone_numbers), "savu.txt", "savu_zone")
+        ave_savu = numpy.searchsorted(intervals, ave_sust_logsum) + 1
+        ave_savu += ((ave_savu - intervals[ave_savu-2])
+                     / (intervals[ave_savu-1] - intervals[ave_savu-2]))
+        self.resultdata.print_line(
+            "Average SAVU:\t{:1.4f}".format(ave_savu),
+            "result_summary")
 
     def _sum_trips_per_zone(self, mode, include_dests=True):
         int_demand = pandas.Series(0, self.zdata_base.zone_numbers)

--- a/Scripts/modelsystem.py
+++ b/Scripts/modelsystem.py
@@ -376,9 +376,9 @@ class ModelSystem:
                 numpy.average(logsum, weights=pop)),
             "result_summary")
         self.resultdata.print_data(logsum, "accessibility.txt", "all")
-        ave_sust_logsum = numpy.average(sust_logsum, weights=pop)
+        avg_sust_logsum = numpy.average(sust_logsum, weights=pop)
         self.resultdata.print_line(
-            "Sustainable accessibility:\t{:1.2f}".format(ave_sust_logsum),
+            "Sustainable accessibility:\t{:1.2f}".format(avg_sust_logsum),
             "result_summary")
         self.resultdata.print_data(
             sust_logsum, "sustainable_accessibility.txt", "all")
@@ -387,11 +387,11 @@ class ModelSystem:
         savu = numpy.searchsorted(intervals, sust_logsum) + 1
         self.resultdata.print_data(
             pandas.Series(savu, zone_numbers), "savu.txt", "savu_zone")
-        ave_savu = numpy.searchsorted(intervals, ave_sust_logsum) + 1
-        ave_savu += ((ave_savu - intervals[ave_savu-2])
-                     / (intervals[ave_savu-1] - intervals[ave_savu-2]))
+        avg_savu = numpy.searchsorted(intervals, avg_sust_logsum) + 1
+        avg_savu += ((avg_savu - intervals[avg_savu-2])
+                     / (intervals[avg_savu-1] - intervals[avg_savu-2]))
         self.resultdata.print_line(
-            "Average SAVU:\t{:1.4f}".format(ave_savu),
+            "Average SAVU:\t{:1.4f}".format(avg_savu),
             "result_summary")
 
     def _sum_trips_per_zone(self, mode, include_dests=True):


### PR DESCRIPTION
SAVU is derived from logsum from sustainable transport modes, according to seven fixed logsum intervals. This addition checks what interval population averaged logsum is in. Additionally, it check how far it is from the next interval, hence adding decimals to the otherwise integer value.