### PR TITLE
Set path properly instead of re-initializing `ResultData` object

### DIFF
--- a/Scripts/datahandling/matrixdata.py
+++ b/Scripts/datahandling/matrixdata.py
@@ -12,10 +12,13 @@ import parameters.assignment as param
 
 class MatrixData:
     def __init__(self, path):
+        self.set_path(path)
+
+    def set_path(self, path):
         self.path = path
         if not os.path.exists(self.path):
             os.makedirs(self.path)
-    
+
     @contextmanager
     def open(self, mtx_type, time_period, zone_numbers=None, m='r'):
         file_name = os.path.join(self.path, mtx_type+'_'+time_period+".omx")

--- a/Scripts/datahandling/resultdata.py
+++ b/Scripts/datahandling/resultdata.py
@@ -12,12 +12,15 @@ class ResultsData:
     Saves all result data to same folder.
     """
     def __init__(self, results_directory_path):
-        if not os.path.exists(results_directory_path):
-            os.makedirs(results_directory_path)
-        self.path = results_directory_path
+        self.set_path(results_directory_path)
         self._line_buffer = {}
         self._df_buffer = {}
         self._xlsx_buffer = {}
+
+    def set_path(self, results_directory_path):
+        if not os.path.exists(results_directory_path):
+            os.makedirs(results_directory_path)
+        self.path = results_directory_path
 
     def flush(self):
         """Save to files and empty buffers."""

--- a/Scripts/helmet.py
+++ b/Scripts/helmet.py
@@ -88,23 +88,23 @@ def main(args):
 
     # Run with increased car ownership
     new_name = args.scenario_name + "_car++"
-    model.resultdata = ResultsData(os.path.join(results_path, new_name))
-    model.resultmatrices = MatrixData(os.path.join(
+    model.resultdata.set_path(os.path.join(results_path, new_name))
+    model.resultmatrices.set_path(os.path.join(
         results_path, new_name, "Matrices"))
     model.cdm.set_car_growth(constant=+0.1)
     run(log_extra, model)
 
     # Run with decreased car ownership
     new_name = args.scenario_name + "_car--"
-    model.resultdata = ResultsData(os.path.join(results_path, new_name))
-    model.resultmatrices = MatrixData(os.path.join(
+    model.resultdata.set_path(os.path.join(results_path, new_name))
+    model.resultmatrices.set_path(os.path.join(
         results_path, new_name, "Matrices"))
     model.cdm.set_car_growth(factor=0.8)
     run(log_extra, model)
 
     # Regular model run last to save regular results in EMME
-    model.resultdata = ResultsData(os.path.join(results_path, args.scenario_name))
-    model.resultmatrices = MatrixData(os.path.join(
+    model.resultdata.set_path(os.path.join(results_path, args.scenario_name))
+    model.resultmatrices.set_path(os.path.join(
         results_path, args.scenario_name, "Matrices"))
     model.cdm.set_car_growth()
     run(log_extra, model)


### PR DESCRIPTION
`ResultData` object stores the result data path. However, the previous fix #402 destroyed this link by creating a new object. Now the path is properly updated, while also creating necessary folders.