### PR TITLE
Fix bike mode and refactor mode handling

### DIFF
--- a/Scripts/assignment/assignment_period.py
+++ b/Scripts/assignment/assignment_period.py
@@ -277,6 +277,8 @@ class AssignmentPeriod(Period):
         network = self.emme_scenario.get_network()
         transit_modesets = {modes[0]: {network.mode(m) for m in modes[1]}
             for modes in param.transit_delay_funcs}
+        main_mode = network.mode(param.main_mode)
+        car_mode = network.mode(param.assignment_modes["car_work"])
         for link in network.links():
             # Car volume delay function definition
             linktype = link.type % 100
@@ -336,16 +338,18 @@ class AssignmentPeriod(Period):
                     break
             for segment in link.segments():
                 segment.transit_time_func = func
-            if network.mode('c') in link.modes:
-                link.modes |= {network.mode('h')}
-            elif network.mode('h') in link.modes:
-                link.modes -= {network.mode('h')}
+            if car_mode in link.modes:
+                link.modes |= {main_mode}
+            elif main_mode in link.modes:
+                link.modes -= {main_mode}
         self.emme_scenario.publish_network(network)
 
     def _set_bike_vdfs(self):
         log.info("Sets bike functions for scenario {}".format(
             self.emme_scenario.id))
         network = self.emme_scenario.get_network()
+        main_mode = network.mode(param.main_mode)
+        bike_mode = network.mode(param.bike_mode)
         for link in network.links():
             linktype = link.type % 100
             if linktype in param.roadclasses:
@@ -366,10 +370,10 @@ class AssignmentPeriod(Period):
                     link.volume_delay_func = pathclass[None]
             except KeyError:
                 link.volume_delay_func = 98
-            if network.mode('f') in link.modes:
-                link.modes |= {network.mode('h')}
-            elif network.mode('h') in link.modes:
-                link.modes -= {network.mode('h')}
+            if bike_mode in link.modes:
+                link.modes |= {main_mode}
+            elif main_mode in link.modes:
+                link.modes -= {main_mode}
         self.emme_scenario.publish_network(network)
 
     def _set_emmebank_matrices(self, matrices, is_last_iteration):
@@ -547,7 +551,7 @@ class AssignmentPeriod(Period):
             "type": "STANDARD_TRAFFIC_ASSIGNMENT",
             "classes": [
                 {
-                    "mode": param.car_mode,
+                    "mode": param.bike_mode,
                     "demand": self.demand_mtx["bike"]["id"],
                     "results": {
                         "od_travel_times": {

--- a/Scripts/parameters/assignment.py
+++ b/Scripts/parameters/assignment.py
@@ -402,7 +402,8 @@ assignment_classes = {
     "oop": "leisure",
     "external": "leisure",
 }
-car_mode = 'c'
+main_mode = 'h'
+bike_mode = 'f'
 assignment_modes = {
     "car_work": 'c',
     "car_leisure": 'c',


### PR DESCRIPTION
By mistake, bike has been assigned to car mode: https://github.com/HSLdevcom/helmet-model-system/pull/290/commits/bd716bd18eadf232ed9d712f8d3e1ee0b3d045f3#diff-592ba4818568720b71888a1390079ea0f3ed8650cbd11e11d33330e0757f9d3bR365
The idea was to assign it to the main `AUTO` mode (which temporally in the previous PR was `c`, but now is `h`).

This PR puts bike assignment back to mode `f`. The main `AUTO` mode is still `h` in bike assignment, but that has no practical implication other than that `h` must also be allowed on the bike links in bike assignment.

At the same time I moved out hard-coded `h`, `f` and `c` from the code, to avoid similar bugs in the future.