### PR TITLE
Fix git tag

### DIFF
--- a/Scripts/utils/config.py
+++ b/Scripts/utils/config.py
@@ -73,7 +73,9 @@ class Config:
         os.chdir(os.path.dirname(os.path.realpath(__file__)))
         try:
             # If model system is in a git repo
-            return subprocess.check_output(["git", "describe", "--tags"])
+            return subprocess.check_output(
+                ["git", "describe", "--tags"], stderr=subprocess.STDOUT,
+                text=True)
         except (subprocess.CalledProcessError, WindowsError):
             # If model system is downloaded with helmet-ui
             return self.HELMET_VERSION

--- a/Scripts/utils/config.py
+++ b/Scripts/utils/config.py
@@ -70,6 +70,7 @@ class Config:
     @property
     def VERSION(self):
         """HELMET version number from git tag or dev_config.json."""
+        os.chdir(os.path.dirname(os.path.realpath(__file__)))
         try:
             # If model system is in a git repo
             return subprocess.check_output(["git", "describe", "--tags"])


### PR DESCRIPTION
This fixes two problems:
1. When run from UI, the os directory is the path of the UI, not the model system. So we need to manually change it to the model system directory to be able to detect git tags.
2. `subprocess.check_output` automatically sends error messages to `stderr`, even if the exception is caught. We can avoid this by sending the error message to `subprocess.STDOUT`, which in this case is the pipe leading to the return value of this function.