### PR TITLE
Add python version check

### DIFF
--- a/Scripts/helmet.py
+++ b/Scripts/helmet.py
@@ -257,4 +257,7 @@ if __name__ == "__main__":
     for key in args_dict:
         log.debug("{}={}".format(key, args_dict[key]))
 
-    main(args)
+    if sys.version_info.major == 3:
+        main(args)
+    else:
+        log.error("Python version not supported, must use version 3")

--- a/Scripts/helmet_validate_inputfiles.py
+++ b/Scripts/helmet_validate_inputfiles.py
@@ -1,5 +1,6 @@
 from argparse import ArgumentParser
 import os
+import sys
 
 import utils.config
 import utils.log as log
@@ -246,4 +247,7 @@ if __name__ == "__main__":
 
     log.initialize(args)
 
-    main(args)
+    if sys.version_info.major == 3:
+        main(args)
+    else:
+        log.error("Python version not supported, must use version 3")


### PR DESCRIPTION
Checks that python 3 is in use. I thought it would be rather unnecessary to restrict it to 3.7, as the system probably works with 3.5, 3.6 and 3.8+ as well. The main point is to shut out 2.7 and give a clear error message about it.