### PR TITLE
Add text file dumping of link attributes with wkt coordinates

### DIFF
--- a/Scripts/assignment/emme_assignment.py
+++ b/Scripts/assignment/emme_assignment.py
@@ -172,6 +172,8 @@ class EmmeAssignmentModel(AssignmentModel):
             linktypes.add(param.roadtypes[linktype])
         linklengths = pandas.Series(0.0, linktypes)
         soft_modes = param.transit_classes + ("bike",)
+        attr_names = self.day_scenario.attributes("LINK")
+        resultdata.print_line("Link\t" + "\t".join(attr_names), "links")
         network = self.day_scenario.get_network()
         for link in network.links():
             linktype = link.type % 100
@@ -197,6 +199,10 @@ class EmmeAssignmentModel(AssignmentModel):
                 linklengths[param.railtypes[linktype]] += link.length
             else:
                 linklengths[param.roadtypes[vdf]] += link.length / 2
+            wkt = "LINESTRING ({} {}, {} {})".format(
+                link.i_node.x, link.i_node.y, link.j_node.x, link.j_node.y)
+            attrs = "\t".join([str(link[attr]) for attr in attr_names])
+            resultdata.print_line(wkt + "\t" + attrs, "links")
         if faulty_kela_code_nodes:
             s = "Municipality KELA code not found for nodes: " + ", ".join(
                 faulty_kela_code_nodes)

--- a/Scripts/assignment/emme_bindings/mock_project.py
+++ b/Scripts/assignment/emme_bindings/mock_project.py
@@ -404,6 +404,11 @@ class Scenario:
     def zone_numbers(self):
         return sorted(self._network._centroids)
 
+    def attributes(self, attr_type):
+        network = self.get_network()
+        # TODO Return other attributes except extra attributes
+        return list(network._extra_attr[attr_type])
+
     def extra_attribute(self, idx):
         network = self.get_network()
         for attr_type in network._extra_attr:


### PR DESCRIPTION
Extracted from #360 and #406, which were part of dropped branch mal23.

If we do not want this as a part of model runs, we could implement it as a Modeller toolbox, similar to the network validation toolbox.