### PR TITLE
Bring car ownership arguments to remote work scenario

### DIFF
--- a/Scripts/helmet.py
+++ b/Scripts/helmet.py
@@ -9,6 +9,7 @@ from assignment.emme_assignment import EmmeAssignmentModel
 from assignment.mock_assignment import MockAssignmentModel
 from modelsystem import ModelSystem, AgentModelSystem
 from datahandling.matrixdata import MatrixData
+from datahandling.resultdata import ResultsData
 
 
 def main(args):
@@ -85,6 +86,43 @@ def main(args):
             results_path, ass_model, args.scenario_name)
     log_extra["status"]["results"] = model.mode_share
 
+    # Regular model run
+    run(log_extra, model)
+
+    # Run with increased car ownership
+    new_name = name + "_car++"
+    model.resultdata = ResultsData(os.path.join(results_path, new_name))
+    model.resultmatrices = MatrixData(
+            os.path.join(results_path, new_name, "Matrices"))
+    model.cdm.set_car_growth(constant=+0.1)
+    run(log_extra, model)
+
+    # Run with decreased car ownership
+    new_name = name + "_car--"
+    model.resultdata = ResultsData(os.path.join(results_path, new_name))
+    model.resultmatrices = MatrixData(
+            os.path.join(results_path, new_name, "Matrices"))
+    model.cdm.set_car_growth(factor=0.8)
+    run(log_extra, model)
+
+    # delete emme strategy files for scenarios
+    if args.del_strat_files:
+        dbase_path = os.path.join(os.path.dirname(emme_project_path), "database")
+        filepath = os.path.join(dbase_path, "STRAT_s{}*")
+        dirpath = os.path.join(dbase_path, "STRATS_s{}", "*")
+        scenario_ids = range(args.first_scenario_id, args.first_scenario_id+5)
+        for s in scenario_ids:
+            strategy_files = glob(filepath.format(s)) + glob(dirpath.format(s))
+            for f in strategy_files:
+                try:
+                    os.remove(f)
+                except:
+                    log.info("Not able to remove file {}.".format(f))
+        log.info("Removed strategy files in {}".format(dbase_path))
+    log.info("Simulation ended.", extra=log_extra)
+
+def run(log_extra, model):
+    iterations = log_extra["total"]
     # Run traffic assignment simulation for N iterations,
     # on last iteration model-system will save the results
     log_extra["status"]["state"] = "preparing"

--- a/Scripts/helmet.py
+++ b/Scripts/helmet.py
@@ -85,10 +85,8 @@ def main(args):
             results_path, ass_model, args.scenario_name)
     log_extra["status"]["results"] = model.mode_share
 
-    # Run with increased car ownership
-    model.cdm.set_car_growth(constant=+0.1)
-    # Run with decreased car ownership
-    model.cdm.set_car_growth(factor=0.8)
+    model.cdm.set_car_growth(constant=args.car_growth_constant,
+                             factor=args.car_growth_factor)
 
     # Run traffic assignment simulation for N iterations,
     # on last iteration model-system will save the results
@@ -252,6 +250,17 @@ if __name__ == "__main__":
         action="store_true",
         default=config.USE_FIXED_TRANSIT_COST,
         help="Using this flag activates use of pre-calculated (fixed) transit costs."),
+    # MAL 2023 input data
+    parser.add_argument(
+        "--car-growth-constant",
+        type=float,
+        default=0.0,
+        help="Car ownership growth constant. To increase, try 0.1."),
+    parser.add_argument(
+        "--car-growth-factor",
+        type=float,
+        default=1.0,
+        help="Car ownership growth factor. To decrease, try 0.8."),
     args = parser.parse_args()
 
     log.initialize(args)

--- a/Scripts/helmet.py
+++ b/Scripts/helmet.py
@@ -122,7 +122,7 @@ def main(args):
     log.info("Simulation ended.", extra=log_extra)
 
 def run(log_extra, model):
-    iterations = log_extra["total"]
+    iterations = log_extra["status"]["total"]
     # Run traffic assignment simulation for N iterations,
     # on last iteration model-system will save the results
     log_extra["status"]["state"] = "preparing"

--- a/Scripts/helmet.py
+++ b/Scripts/helmet.py
@@ -9,7 +9,6 @@ from assignment.emme_assignment import EmmeAssignmentModel
 from assignment.mock_assignment import MockAssignmentModel
 from modelsystem import ModelSystem, AgentModelSystem
 from datahandling.matrixdata import MatrixData
-from datahandling.resultdata import ResultsData
 
 
 def main(args):
@@ -86,43 +85,11 @@ def main(args):
             results_path, ass_model, args.scenario_name)
     log_extra["status"]["results"] = model.mode_share
 
-    # Regular model run
-    run(log_extra, model)
-
     # Run with increased car ownership
-    new_name = name + "_car++"
-    model.resultdata = ResultsData(os.path.join(results_path, new_name))
-    model.resultmatrices = MatrixData(
-            os.path.join(results_path, new_name, "Matrices"))
     model.cdm.set_car_growth(constant=+0.1)
-    run(log_extra, model)
-
     # Run with decreased car ownership
-    new_name = name + "_car--"
-    model.resultdata = ResultsData(os.path.join(results_path, new_name))
-    model.resultmatrices = MatrixData(
-            os.path.join(results_path, new_name, "Matrices"))
     model.cdm.set_car_growth(factor=0.8)
-    run(log_extra, model)
 
-    # delete emme strategy files for scenarios
-    if args.del_strat_files:
-        dbase_path = os.path.join(os.path.dirname(emme_project_path), "database")
-        filepath = os.path.join(dbase_path, "STRAT_s{}*")
-        dirpath = os.path.join(dbase_path, "STRATS_s{}", "*")
-        scenario_ids = range(args.first_scenario_id, args.first_scenario_id+5)
-        for s in scenario_ids:
-            strategy_files = glob(filepath.format(s)) + glob(dirpath.format(s))
-            for f in strategy_files:
-                try:
-                    os.remove(f)
-                except:
-                    log.info("Not able to remove file {}.".format(f))
-        log.info("Removed strategy files in {}".format(dbase_path))
-    log.info("Simulation ended.", extra=log_extra)
-
-def run(log_extra, model):
-    iterations = log_extra["status"]["total"]
     # Run traffic assignment simulation for N iterations,
     # on last iteration model-system will save the results
     log_extra["status"]["state"] = "preparing"

--- a/Scripts/models/linear.py
+++ b/Scripts/models/linear.py
@@ -80,10 +80,24 @@ class CarDensityModel(LinearModel):
             out=numpy.array(forecast_sh_detached), where=pop_growth!=0)
         self.zone_data._values["share_detached_houses_new"] = pandas.Series(
             share_detached_new, self.zone_data.zone_numbers[self.bounds])
-    
+        self.set_car_growth()
+
+    def set_car_growth(self, constant=0.0, factor=1.0):
+        """Set extra car ownership growth for sensitivity analyses.
+
+        Parameters
+        ----------
+        constant : float (optional)
+            Constant to add to prediction
+        factor : float (optional)
+            Factor to multiply prediction by
+        """
+        self._growth_constant = constant
+        self._growth_factor = factor
+
     def predict(self):
         """Get car ownership prediction for zones.
-        
+
         Return
         ------
         pandas.Series
@@ -108,6 +122,8 @@ class CarDensityModel(LinearModel):
                             .clip(upper=1.0))
         prediction = (self.pop_growth_share * prediction
                       + (1-self.pop_growth_share) * base_car_density)
+        prediction += self._growth_constant
+        prediction *= self._growth_factor
         self.print_results(prediction)
         return prediction
 


### PR DESCRIPTION
We noticed that some sensitivity anmalysis scenarios need both remote work generation and car ownership changes enabled.