### PR TITLE
Allow trucks on bus lanes, do separate truck end assignment

### DIFF
--- a/Scripts/assignment/assignment_period.py
+++ b/Scripts/assignment/assignment_period.py
@@ -502,7 +502,7 @@ class AssignmentPeriod(Period):
                     link[background_traffic] = 0
                 else:
                     link[background_traffic] = freq
-                    if include_trucks
+                    if include_trucks:
                         for ass_class in heavy:
                             link[background_traffic] += link[ass_class]
         self.emme_scenario.publish_network(network)
@@ -514,14 +514,14 @@ class AssignmentPeriod(Period):
         background_traffic = param.background_traffic_attr.replace(
             "ul", "data")
         # calc @bus and data3
-        ligth_vehicles = (
+        light_vehicles = (
             self.extra("car_work"), self.extra("car_leisure"),
             self.extra("van"))
         for link in network.links():
             if link.type > 100: # If car or bus link
                 link[background_traffic] = 0
                 if not link.type // 100 in param.bus_lane_link_codes[self.name]:
-                    for ass_class in ligth_vehicles:
+                    for ass_class in light_vehicles:
                         link[background_traffic] += link[ass_class]
         self.emme_scenario.publish_network(network)
 

--- a/Scripts/assignment/assignment_period.py
+++ b/Scripts/assignment/assignment_period.py
@@ -127,6 +127,7 @@ class AssignmentPeriod(Period):
             self._set_car_and_transit_vdfs()
             self._calc_background_traffic(include_trucks=True)
             self._assign_cars(param.stopping_criteria_fine, lightweight=True)
+            self._calc_background_cars()
             self._assign_cars(param.stopping_criteria_fine, trucks=True)
             self._calc_boarding_penalties(is_last_iteration=True)
             self._calc_extra_wait_time()
@@ -513,7 +514,7 @@ class AssignmentPeriod(Period):
         # emme api has name "data3" for ul3
         background_traffic = param.background_traffic_attr.replace(
             "ul", "data")
-        # calc @bus and data3
+        # calc data3
         light_vehicles = (
             self.extra("car_work"), self.extra("car_leisure"),
             self.extra("van"))

--- a/Scripts/assignment/datatypes/car_specification.py
+++ b/Scripts/assignment/datatypes/car_specification.py
@@ -53,12 +53,17 @@ class CarSpecification:
             "stopping_criteria": None, # This is defined later
         }
 
-    def spec (self, lightweight=False):
+    def spec (self, lightweight=False, trucks=False):
         if lightweight:
             self._spec["classes"] = [
                 self.car_work.spec,
                 self.car_leisure.spec,
                 self.van.spec,
+            ]
+        elif trucks:
+            self._spec["classes"] = [
+                self.trailer_truck.spec,
+                self.truck.spec,
             ]
         else:
             self._spec["classes"] = [


### PR DESCRIPTION
This is not supposed to be merged with olusanya!

To be able to analyze trucks allowed on bus lanes, we need to do a separate assignment for them, where light traffic is background traffic, except on links with bus lanes.