### PR TITLE
Fix floating-point number error

### DIFF
--- a/Scripts/assignment/assignment_period.py
+++ b/Scripts/assignment/assignment_period.py
@@ -200,7 +200,7 @@ class AssignmentPeriod(Period):
                 "trip_part_transit_work", "board_cost")
             # If the number of visits is less than 1, there seems to
             # be an easy way to avoid visiting this transit zone
-            has_visited[transit_zone] = (nr_visits >= 1)
+            has_visited[transit_zone] = (nr_visits > 0.99)
         for centroid in network.centroids():
             # Add transit zone of destination to visited
             has_visited[centroid.label][:, mapping[centroid.number]] = True


### PR DESCRIPTION
Fixes problem where some random OD pairs had too low transit fare, because some boarding locations were not detected. Tested that this gives approximately the same overall mode shares as previously.