### PR TITLE
Change model run defaults

### DIFF
--- a/Scripts/dev-config.json
+++ b/Scripts/dev-config.json
@@ -9,7 +9,7 @@
     "FIRST_MATRIX_ID": 100,
     "BASELINE_DATA_PATH": "C:\\XXX\\Lahtodata",
     "FORECAST_DATA_PATH": "C:\\XXX\\Ennusteskenaarioiden_syottotiedot\\2017",
-    "ITERATION_COUNT": 10,
+    "ITERATION_COUNT": 15,
     "MAX_GAP": 1.0,
     "REL_GAP": 0.01,
     "OPTIONAL_FLAGS": []

--- a/Scripts/parameters/assignment.py
+++ b/Scripts/parameters/assignment.py
@@ -241,14 +241,14 @@ headway_sd_func = {
 }
 # Stopping criteria for last traffic assignment
 stopping_criteria_fine = {
-    "max_iterations": 200,
+    "max_iterations": 400,
     "relative_gap": 0.00001,
     "best_relative_gap": 0.001,
     "normalized_gap": 0.0005,
 }
 # Stopping criteria for traffic assignment in loop
 stopping_criteria_coarse = {
-    "max_iterations": 100,
+    "max_iterations": 200,
     "relative_gap": 0.0001,
     "best_relative_gap": 0.01,
     "normalized_gap": 0.005,


### PR DESCRIPTION
MAL 2040 ve0 and ve2 model runs need higher counts on both car assignment and demand model iterations to fully converge. This will add run time only on those model runs which have trouble converging. Other model runs (eg. 2018 or 2023) converge early and do not take extra time.
