### PR TITLE
Fix headways in extra waiting times

### DIFF
--- a/Scripts/assignment/assignment_period.py
+++ b/Scripts/assignment/assignment_period.py
@@ -743,7 +743,8 @@ class AssignmentPeriod(Period):
                                   + b["ctime"]*cumulative_time
                                   + b["cspeed"]*cumulative_speed)
                 # Estimated waiting time addition caused by headway deviation
-                segment["@wait_time_dev"] = headway_sd**2 / (2.0*line.headway)
+                headway_attr = self.extra("hw")
+                segment["@wait_time_dev"] = headway_sd**2 / (2.0*line[headway_attr])
         self.emme_scenario.publish_network(network)
 
     def _assign_transit(self):

--- a/Scripts/assignment/assignment_period.py
+++ b/Scripts/assignment/assignment_period.py
@@ -690,6 +690,7 @@ class AssignmentPeriod(Period):
     def _calc_extra_wait_time(self):
         """Calculate extra waiting time for one scenario."""
         network = self.emme_scenario.get_network()
+        headway_attr = self.extra("hw")
         # Calculation of cumulative line segment travel time and speed
         log.info("Calculates cumulative travel times for scenario " + str(self.emme_scenario.id))
         for line in network.transit_lines():
@@ -743,7 +744,6 @@ class AssignmentPeriod(Period):
                                   + b["ctime"]*cumulative_time
                                   + b["cspeed"]*cumulative_speed)
                 # Estimated waiting time addition caused by headway deviation
-                headway_attr = self.extra("hw")
                 segment["@wait_time_dev"] = headway_sd**2 / (2.0*line[headway_attr])
         self.emme_scenario.publish_network(network)
 


### PR DESCRIPTION
Fixes a bug where headways in function `_calc_extra_wait_time()` were read from Emme networks instead of extra attributes. This caused the first model run to have different results than the following model runs, because the first run reads them from `transit_lines_xxx.txt` and other runs read them from the last congested transit assignment i.e. `@hw_iht`: https://github.com/HSLdevcom/helmet-model-system/blob/089f9c43113a97aaf5e9e975887eddf07ebe2330/Scripts/assignment/assignment_period.py#L766-L769

Fixes #484 