### PR TITLE
Add scenario id when setting and getting emme matrices

### DIFF
--- a/Scripts/assignment/assignment_period.py
+++ b/Scripts/assignment/assignment_period.py
@@ -411,10 +411,12 @@ class AssignmentPeriod(Period):
             raise ValueError(msg)
         elif result_type is None:
             self.emme_project.modeller.emmebank.matrix(
-                self.demand_mtx[mtx_label]["id"]).set_numpy_data(matrix)
+                self.demand_mtx[mtx_label]["id"]).set_numpy_data(
+                    matrix, scenario_id=self.emme_scenario.id)
         else:
             self.emme_project.modeller.emmebank.matrix(
-                self.result_mtx[result_type][mtx_label]["id"]).set_numpy_data(matrix)
+                self.result_mtx[result_type][mtx_label]["id"]).set_numpy_data(
+                    matrix, scenario_id=self.emme_scenario.id)
 
     def _get_matrices(self, mtx_type, is_last_iteration=False):
         """Get all matrices of specified type.
@@ -465,7 +467,7 @@ class AssignmentPeriod(Period):
         """
         emme_id = self.result_mtx[assignment_result_type][subtype]["id"]
         return (self.emme_project.modeller.emmebank.matrix(emme_id)
-                .get_numpy_data())
+                .get_numpy_data(scenario_id=self.emme_scenario.id))
 
     def _damp_travel_time(self, demand_type):
         """Reduce the impact from first waiting time on total travel time."""

--- a/Scripts/assignment/emme_assignment.py
+++ b/Scripts/assignment/emme_assignment.py
@@ -274,7 +274,7 @@ class EmmeAssignmentModel(AssignmentModel):
         for ap in self.assignment_periods:
             for transit_class in param.transit_classes:
                 idx = ap.result_mtx["cost"][transit_class]["id"]
-                emmebank.matrix(idx).set_numpy_data(cost, ap.scenario.id)
+                emmebank.matrix(idx).set_numpy_data(cost, ap.emme_scenario.id)
             if not self.save_matrices:
                 break
 

--- a/Scripts/assignment/emme_assignment.py
+++ b/Scripts/assignment/emme_assignment.py
@@ -274,7 +274,7 @@ class EmmeAssignmentModel(AssignmentModel):
         for ap in self.assignment_periods:
             for transit_class in param.transit_classes:
                 idx = ap.result_mtx["cost"][transit_class]["id"]
-                emmebank.matrix(idx).set_numpy_data(cost)
+                emmebank.matrix(idx).set_numpy_data(cost, ap.scenario.id)
             if not self.save_matrices:
                 break
 

--- a/Scripts/assignment/emme_bindings/mock_project.py
+++ b/Scripts/assignment/emme_bindings/mock_project.py
@@ -465,10 +465,10 @@ class Matrix:
         self.id = idx
         self._data = numpy.full((dim, dim), default_value, dtype=float)
 
-    def get_numpy_data(self, scenario_id):
+    def get_numpy_data(self, scenario_id=None):
         return self._data
 
-    def set_numpy_data(self, data, scenario_id):
+    def set_numpy_data(self, data, scenario_id=None):
         self._data[:,:] = data
 
 

--- a/Scripts/assignment/emme_bindings/mock_project.py
+++ b/Scripts/assignment/emme_bindings/mock_project.py
@@ -465,10 +465,10 @@ class Matrix:
         self.id = idx
         self._data = numpy.full((dim, dim), default_value, dtype=float)
 
-    def get_numpy_data(self):
+    def get_numpy_data(self, scenario_id):
         return self._data
 
-    def set_numpy_data(self, data):
+    def set_numpy_data(self, data, scenario_id):
         self._data[:,:] = data
 
 

--- a/Scripts/helmet_validate_inputfiles.py
+++ b/Scripts/helmet_validate_inputfiles.py
@@ -161,6 +161,9 @@ def main(args):
                     scen.id)
                 log.error(msg)
                 raise ValueError(msg)
+            for scen in emmebank.scenarios():
+                if scen.zone_numbers != zone_numbers:
+                    log.warn("Scenarios with different zones found in EMME bank!")
             attrs = (
                 "@pyoratieluokka",
                 "@hinta_aht",


### PR DESCRIPTION
@samakinen suggested this change, which prohibits sudden crashes when emme scenarios have different number of zones.

I do not think it is good practice to mix different zone systems (and hence differently sized matrices) in the same emme bank, but I admit that it might sometimes be handy to be able to try small zone splittings in an emme scenario without having to create an entirely new emme bank. And most importantly, the system should not crash unexpectedly because of such a choice.