### PR TITLE
Change iteration number counting

### DIFF
--- a/Scripts/assignment/assignment_period.py
+++ b/Scripts/assignment/assignment_period.py
@@ -643,7 +643,7 @@ class AssignmentPeriod(Period):
             self.emme_scenario.id))
         log.info("Stopping criteria: {}, iteration {} / {}".format(
             assign_report["stopping_criterion"],
-            assign_report["iterations"][-1]["number"],
+            len(assign_report["iterations"]),
             stopping_criteria["max_iterations"]
             ))
         if assign_report["stopping_criterion"] == "MAX_ITERATIONS":


### PR DESCRIPTION
The current method cannot handle zero car assignment iterations, because in that case `assign_report["iterations"]` is an empty list. Using zero iterations is a convenient way of doing free-flow assignment.