### PR TITLE
Update transit fare dtype

### DIFF
--- a/Scripts/datahandling/zonedata.py
+++ b/Scripts/datahandling/zonedata.py
@@ -35,8 +35,7 @@ class ZoneData:
             dtype)
         transit = read_csv_file(data_dir, ".tco")
         try:
-            transit["fare"] = transit["fare"].astype(
-                dtype=float, errors='raise')
+            transit["fare"] = transit["fare"].astype(dtype, errors='raise')
         except ValueError:
             msg = "Zonedata file .tco has fare values not convertible to float"
             log.error(msg)


### PR DESCRIPTION
In #495 I had forgot to change one `dtype` setting, because we have removed it in our Traficom fork of this repo.