### PR TITLE
Copy matrix folder from test scenario

### DIFF
--- a/Scripts/helmet_validate_inputfiles.py
+++ b/Scripts/helmet_validate_inputfiles.py
@@ -59,10 +59,10 @@ def main(args):
         mock_result_path = os.path.join(
             args.results_path, args.scenario_name, "Matrices")
         if not os.path.exists(mock_result_path):
-            msg = "Mock Results directory {} does not exist.".format(
-                mock_result_path)
-            log.error(msg)
-            raise NameError(msg)
+            log.info("Matrices folder does not exist, copying the folder from test scenario")
+            test_path = os.path.join(args.results_path,"test","Matrices")
+            import shutil
+            shutil.copytree(test_path, mock_result_path)
         assignment_model = MockAssignmentModel(MatrixData(mock_result_path))
         zone_numbers = assignment_model.zone_numbers
     else:


### PR DESCRIPTION
It's one small step for mock run, one giant leap for testing? Or not so much, but at least should enable having multiple testing scenarios under different names without having to move things in the folders manually.