### PR TITLE
Add support for custom centroid range

### DIFF
--- a/Scripts/datahandling/zonedata.py
+++ b/Scripts/datahandling/zonedata.py
@@ -33,7 +33,7 @@ class ZoneData:
         parkdata = read_csv_file(data_dir, ".prk", self.zone_numbers, dtype)
         self.externalgrowth = read_csv_file(
             data_dir, ".ext",
-            all_zone_numbers[all_zone_numbers.searchsorted(external[0]):],
+            all_zone_numbers[all_zone_numbers.searchsorted(external[0]):all_zone_numbers.searchsorted(external[1],side='right')],
             dtype)
         transit = read_csv_file(data_dir, ".tco")
         try:

--- a/Scripts/parameters/zone.py
+++ b/Scripts/parameters/zone.py
@@ -112,7 +112,7 @@ purpose_areas: Dict[str, Union[Tuple[int,int],Tuple[int,int,int]]] = {
     "metropolitan": (0, 6000, 16000),
     "peripheral": (16000, 31000),
     "all": (0, 6000, 31000),
-    "external": (31031, 40000),
+    "external": (31031, 34999),
 }
 areas = {
     "helsinki_cbd": (0, 999),
@@ -132,7 +132,7 @@ areas = {
         (15000, 15499),
     ),
     "peripheral": (16000, 30999),
-    "external": (31031, None),
+    "external": (31031, 34999),
 }
 municipalities = {
     "Helsinki": (0, 1999),


### PR DESCRIPTION
Creates support for "wild centroids" for IDs between 35 000 – 40 000 as stated in the Helmet manual.