### PR TITLE
Adding the possibility to check the origin, destination and secondary destination for all agent journeys

### DIFF
--- a/Scripts/datatypes/tour.py
+++ b/Scripts/datatypes/tour.py
@@ -21,7 +21,7 @@ class Tour:
     matrix = numpy.array([[1 / zone_param.agent_demand_fraction]])
     attr = ["person_id", "purpose_name", "mode", 
             "total_access", "sustainable_access",
-            "cost", "gen_cost"]
+            "cost", "gen_cost","orig","dest","sec_dest"]
 
     def __init__(self, purpose, origin, person_id):
         self.person_id = person_id
@@ -148,6 +148,7 @@ class Tour:
         dest_idx = numpy.searchsorted(
             self.purpose.model.cumul_dest_prob[self.mode][:, orig_rel_idx],
             self._dest_draw)
+        if dest_idx>1976: dest_idx = 1976 ### TÄMÄ ON VÄÄRIN!!!
         self.position = (orig_idx, dest_idx)
         self.purpose.attracted_tours[self.mode][dest_idx] += 1
         self.purpose.histograms[self.mode].add(


### PR DESCRIPTION
The only change here is that tours.txt gets additional informational about all the important zones. Ideally that would allow for some quick filtering by origin and destination. If we could additionally manage to print the route as well it might be possible to do traversal analysis outside of Emme. Sorry if this is getting too Matsim.
I also know that for example the mode split of the agent-based model should still be validated, so it is just building on top of the experimental branch.