### PR TITLE
Assign bikes as F mode

### DIFF
--- a/Scripts/assignment/assignment_period.py
+++ b/Scripts/assignment/assignment_period.py
@@ -99,6 +99,7 @@ class AssignmentPeriod(Period):
         self._calc_boarding_penalties()
         self._calc_background_traffic()
         self._specify()
+        self._fill_h_mode()
 
     def assign(self, matrices: dict, iteration: Union[int,str]) -> Dict:
         """Assign cars, bikes and transit for one time period.
@@ -121,7 +122,6 @@ class AssignmentPeriod(Period):
         self.event_handler.on_assignment_started(self, iteration, matrices)
         self._set_emmebank_matrices(matrices, iteration=="last")
         if iteration=="init":
-            self._fill_h_mode()
             self._assign_pedestrians()
             self._set_bike_vdfs()
             self._assign_bikes(self.emme_matrices["bike"]["dist"], "all")
@@ -132,8 +132,6 @@ class AssignmentPeriod(Period):
             self._calc_extra_wait_time()
             self._assign_congested_transit() if param.always_congested else self._assign_transit()
         elif iteration==0:
-            if self._separate_emme_scenarios:
-                self._fill_h_mode()
             self._set_bike_vdfs()
             self._assign_bikes(self.emme_matrices["bike"]["dist"], "all")
             self._set_car_and_transit_vdfs()

--- a/Scripts/assignment/emme_bindings/mock_project.py
+++ b/Scripts/assignment/emme_bindings/mock_project.py
@@ -564,6 +564,13 @@ class Network:
         mode = Mode(idx, mode_type)
         self._modes[idx] = mode
         return mode
+    
+    def delete_mode(self, idx: str, cascade: bool = False):
+        mode = self._modes[idx]
+        if cascade:
+            for link in self._links:
+                self._links[link].modes -= {mode}
+        self._modes.pop(idx)
 
     def node(self, idx: int) -> 'Node':
         idx = int(idx)

--- a/Scripts/models/logit.py
+++ b/Scripts/models/logit.py
@@ -59,6 +59,8 @@ class LogitModel:
             exps = numpy.exp(utility)
             self.mode_exps[mode] = exps
             expsum += exps
+        if expsum.min() == 0:
+            raise ValueError("Exponentiated utility sum must be greater than zero. The impedance might be too high.")
         return expsum
     
     def _calc_dest_util(self, mode, impedance):

--- a/Scripts/parameters/assignment.py
+++ b/Scripts/parameters/assignment.py
@@ -435,6 +435,7 @@ assignment_classes = {
 }
 main_mode = 'h'
 bike_mode = 'f'
+bike_mode_traffic = 'F'
 assignment_modes = {
     "car_work": 'c',
     "car_leisure": 'c',

--- a/Scripts/parameters/assignment.py
+++ b/Scripts/parameters/assignment.py
@@ -435,7 +435,6 @@ assignment_classes = {
 }
 main_mode = 'h'
 bike_mode = 'f'
-bike_mode_traffic = 'F'
 assignment_modes = {
     "car_work": 'c',
     "car_leisure": 'c',

--- a/Scripts/tests/test_data/Network/modes_test.txt
+++ b/Scripts/tests/test_data/Network/modes_test.txt
@@ -9,6 +9,7 @@ a c 'Auto'     4   1
 a v 'Pakettiaut' 4   1
 a k 'Kuorma-aut' 4   1
 a y 'KA peravau' 4   1
+a f 'Polkupyora' 4   1
 a b 'HSL-bussi' 2   1
 a g 'HSL-runkob' 2   1
 a d 'Muu bussi' 2   1
@@ -21,4 +22,3 @@ a p 'Pikaratikk' 2   1
 a w 'Vesiliiken' 2   1
 a a 'Kavely'   3   1   0.00   0.00   0.00   0.00          5.0
 a s 'Ulkokavely' 3   1   0.00   0.00   0.00   0.00          5.0
-a f 'Polkupyora' 3   1   0.00   0.00   0.00   0.00         17.0

--- a/Scripts/utils/validate_network.py
+++ b/Scripts/utils/validate_network.py
@@ -99,6 +99,11 @@ def validate(network, fares=None):
             msg = "Link id {} type must not be 999, please refer to the helmet-docs manual".format(link.id)
             log.error(msg)
             raise ValueError(msg)
+        if link.length > 200:
+            log.warn(
+            "Link id {} has length {} km. Project settings might be incorrect".format(
+                link.id, link.length
+            ))
         
         linktype = link.type % 100
         if (linktype != 70 and link.length == 0): 

--- a/Scripts/utils/validate_network.py
+++ b/Scripts/utils/validate_network.py
@@ -48,11 +48,11 @@ def validate(network, fares=None):
             log.error(msg)
             raise ValueError(msg)
     validate_mode(network, param.main_mode, EMME_AUTO_MODE)
-    for m in param.assignment_modes.values():
+    for m in list(param.assignment_modes.values()) + [param.bike_mode]:
         validate_mode(network, m, EMME_AUX_AUTO_MODE)
     for m in param.transit_modes:
         validate_mode(network, m, EMME_TRANSIT_MODE)
-    for m in param.aux_modes + [param.bike_mode]:
+    for m in param.aux_modes:
         validate_mode(network, m, EMME_AUX_TRANSIT_MODE)
     modesets = []
     intervals = []


### PR DESCRIPTION
As of now, bike assignment is done as "h" mode. This creates issues with turning restrictions, because the information about turning restrictions is kept in the "h" mode. However, on links like "hcvky", "h" mode is removed for bike assignment and at the same time any possible turning restrictions for cars are removed as well. Once we proceed into car assignment, "cvky" turns back into "hcvky", but the turning restriction is missing - it disappears. 
As a remedy, I propose to do the bike assignment properly, as a "F" mode subnetwork of the "h" mode main network. Due to backwards compatilbility, "F" mode is only used as virtual "AUX_AUTO" mode. "f" mode on the other hand is "AUX_TRANSIT". There probably used to be some idea in the past to use transit assignment for bikes, but it remained unimplemented. 
When I implemented the change, some things did not work out of the box, there needs to be valid vdf, valid number of lanes and valid time_auto travel time. They are not used in the assignments to my understanding, but they are required for the initial checks. All these adjustments are part of this PR.
This PR should close this issue:
#583 

Note: I am only pushing this into Helmet 5 as olusanya had this behavior since the beginning.