### PR TITLE
596 cba compatibility w/ old mal scenarios

### DIFF
--- a/Scripts/cba.py
+++ b/Scripts/cba.py
@@ -222,15 +222,15 @@ def run_cost_benefit_analysis(scenario_0, scenario_1, year, workbook):
     if not all(submode in transit_mile_diff.index for submodes in transit_aggs.values() for submode in submodes):
         transit_aggs = TRANSIT_AGGREGATIONS_FALLBACK
         mal2023 = True
+        log.info("Using fallback transit aggregations for MAL2023 scenario")
     for mode in transit_aggs:
         transit_mile_diff.loc[mode] = 0
-        for submode in TRANSIT_AGGREGATIONS[mode]:
+        for submode in transit_aggs[mode]:
             transit_mile_diff.loc[mode] += transit_mile_diff.loc[submode]
     ws = workbook["Tuottajahyodyt"]
     cols = CELL_INDICES["transit_miles"]["cols"]
     rows = CELL_INDICES["transit_miles"]["rows"][year]
     if mal2023:
-        log.warning("Using fallback transit aggregations for MAL2023 scenario")
         rows["HSL-runkob"] = rows["trunk"]
         rows.pop("trunk")
     for mode in rows:

--- a/Scripts/cba.py
+++ b/Scripts/cba.py
@@ -34,6 +34,7 @@ TRANSIT_AGGREGATIONS = {
 }
 TRANSIT_AGGREGATIONS_FALLBACK = {
     "bus": ("HSL-bussi", "ValluVakio", "ValluPika"),
+    "trunk": ("HSL-runkob", ),
     "train": ("HSL-juna", "muu_juna"),
     "tram": ("ratikka", "pikaratikk"),
 }
@@ -214,25 +215,21 @@ def run_cost_benefit_analysis(scenario_0, scenario_1, year, workbook):
     noise_diff = read(NOISE_FILE, scenario_1) - read(NOISE_FILE, scenario_0)
     ws[CELL_INDICES["noise"][year]] = sum(noise_diff["population"])
 
+    transit_vehicle_kms_tables = [read(TRANSIT_KMS_FILE, scenario_0), read(TRANSIT_KMS_FILE, scenario_1)]
+    for transit_vehicle_kms in transit_vehicle_kms_tables:
+        if all(submode in transit_vehicle_kms.index for submodes in TRANSIT_AGGREGATIONS.values() for submode in submodes):
+            transit_aggs = TRANSIT_AGGREGATIONS
+        else:
+            transit_aggs = TRANSIT_AGGREGATIONS_FALLBACK
+        for mode in transit_aggs:
+            transit_vehicle_kms.loc[mode] = 0  # Change aggregated mode to 0
+            for submode in transit_aggs[mode]:  # Go through the submodes and add their values to the aggregated mode
+                transit_vehicle_kms.loc[mode] += transit_vehicle_kms.loc[submode]
     # Calculate transit mile differences
-    transit_mile_diff = (read(TRANSIT_KMS_FILE, scenario_1)
-                         - read(TRANSIT_KMS_FILE, scenario_0))
-    # Fallback to older aggregation if the scenario is using the old vehicles (MAL2023)
-    transit_aggs = TRANSIT_AGGREGATIONS
-    if not all(submode in transit_mile_diff.index for submodes in transit_aggs.values() for submode in submodes):
-        transit_aggs = TRANSIT_AGGREGATIONS_FALLBACK
-        mal2023 = True
-        log.info("Using fallback transit aggregations for MAL2023 scenario")
-    for mode in transit_aggs:
-        transit_mile_diff.loc[mode] = 0
-        for submode in transit_aggs[mode]:
-            transit_mile_diff.loc[mode] += transit_mile_diff.loc[submode]
+    transit_mile_diff = transit_vehicle_kms_tables[1] - transit_vehicle_kms_tables[0]
     ws = workbook["Tuottajahyodyt"]
     cols = CELL_INDICES["transit_miles"]["cols"]
     rows = CELL_INDICES["transit_miles"]["rows"][year]
-    if mal2023:
-        rows["HSL-runkob"] = rows["trunk"]
-        rows.pop("trunk")
     for mode in rows:
         for imp_type in cols:
             ws[cols[imp_type]+rows[mode]] = transit_mile_diff[imp_type][mode]
@@ -433,6 +430,13 @@ if __name__ == "__main__":
         help="Path to Results directory.")
     args = parser.parse_args()
     log.initialize(args)
+    
+    matching_vehicle_kms_cols = list(read(VEHICLE_KMS_FILE, args.baseline_scenario).columns) == list(read(VEHICLE_KMS_FILE, args.projected_scenario).columns)
+    matching_transit_kms_rows = list(read(TRANSIT_KMS_FILE, args.baseline_scenario).index) == list(read(TRANSIT_KMS_FILE, args.projected_scenario).index)
+    if not (matching_vehicle_kms_cols and matching_transit_kms_rows):
+        msg = "The data structure of transit_kms.txt or vehicle_kms_vdf.txt is different between scenarios. Check the results folders of scenarios being compared."
+        log.error(msg)
+        raise KeyError(msg)
     wb = load_workbook(os.path.join(SCRIPT_DIR, "CBA_kehikko.xlsx"))
     results = run_cost_benefit_analysis(
         args.baseline_scenario, args.projected_scenario, 1, wb)

--- a/Scripts/cba.py
+++ b/Scripts/cba.py
@@ -32,6 +32,12 @@ TRANSIT_AGGREGATIONS = {
     "train": ("HSL-juna-2", "muu_juna", "HSL-juna-1", "HSL-juna-3"),
     "tram": ("ratikka", "pikaratikk"),
 }
+TRANSIT_AGGREGATIONS_FALLBACK = {
+    "bus": ("HSL-bussi", "ValluVakio", "ValluPika"),
+    "trunk": ("HSL-runkob",),
+    "train": ("HSL-juna", "muu_juna"),
+    "tram": ("ratikka", "pikaratikk"),
+}
 
 TRANSLATIONS = {
     "car_work": "ha_tyo",
@@ -212,7 +218,11 @@ def run_cost_benefit_analysis(scenario_0, scenario_1, year, workbook):
     # Calculate transit mile differences
     transit_mile_diff = (read(TRANSIT_KMS_FILE, scenario_1)
                          - read(TRANSIT_KMS_FILE, scenario_0))
-    for mode in TRANSIT_AGGREGATIONS:
+    # Fallback to older aggregation if the scenario is using the old vehicles (MAL2023)
+    transit_aggs = TRANSIT_AGGREGATIONS
+    if not all(submode in transit_mile_diff.index for submodes in transit_aggs.values() for submode in submodes):
+        transit_aggs = TRANSIT_AGGREGATIONS_FALLBACK
+    for mode in transit_aggs:
         transit_mile_diff.loc[mode] = 0
         for submode in TRANSIT_AGGREGATIONS[mode]:
             transit_mile_diff.loc[mode] += transit_mile_diff.loc[submode]

--- a/Scripts/cba.py
+++ b/Scripts/cba.py
@@ -34,7 +34,6 @@ TRANSIT_AGGREGATIONS = {
 }
 TRANSIT_AGGREGATIONS_FALLBACK = {
     "bus": ("HSL-bussi", "ValluVakio", "ValluPika"),
-    "trunk": ("HSL-runkob",),
     "train": ("HSL-juna", "muu_juna"),
     "tram": ("ratikka", "pikaratikk"),
 }
@@ -222,6 +221,7 @@ def run_cost_benefit_analysis(scenario_0, scenario_1, year, workbook):
     transit_aggs = TRANSIT_AGGREGATIONS
     if not all(submode in transit_mile_diff.index for submodes in transit_aggs.values() for submode in submodes):
         transit_aggs = TRANSIT_AGGREGATIONS_FALLBACK
+        mal2023 = True
     for mode in transit_aggs:
         transit_mile_diff.loc[mode] = 0
         for submode in TRANSIT_AGGREGATIONS[mode]:
@@ -229,6 +229,10 @@ def run_cost_benefit_analysis(scenario_0, scenario_1, year, workbook):
     ws = workbook["Tuottajahyodyt"]
     cols = CELL_INDICES["transit_miles"]["cols"]
     rows = CELL_INDICES["transit_miles"]["rows"][year]
+    if mal2023:
+        log.warning("Using fallback transit aggregations for MAL2023 scenario")
+        rows["HSL-runkob"] = rows["trunk"]
+        rows.pop("trunk")
     for mode in rows:
         for imp_type in cols:
             ws[cols[imp_type]+rows[mode]] = transit_mile_diff[imp_type][mode]


### PR DESCRIPTION
Fixed compatibility with MAL2023 scenarios that still use the older vehicle definitions

How it works:

Check if transit_kms file includes all the submodes grouped into aggregations. 
If not, fallback to older definitions and set mal2023 flag
If the flag is set, also replace the "trunk" aggregation title from the excel cell indices dictionary with "HSL-runkob"