### PR TITLE
Results pnr bug fix

### DIFF
--- a/Scripts/events/results/results_summary.py
+++ b/Scripts/events/results/results_summary.py
@@ -111,6 +111,7 @@ class ResultSummary(ModelSystemEventListener):
                         hs15_modes_total[mode] += demsum * (2+tour_generation["hoo"][purpose.name][mode]) #sec_dest included
         hs15_modes_shares = {m: hs15_modes_total[m]/sum(hs15_modes_total.values()) for m in hs15_modes_total}
         hs15_modes = [m for m in hs15_modes_total]
+        hs15_modes.remove("park_and_ride")
         self.ms.resultdata.print_line("\nHS15 mode shares (trip-based with secondary destinations)", "result_summary")
         for m in hs15_modes:
             self.ms.resultdata.print_line(

--- a/Scripts/modelsystem.py
+++ b/Scripts/modelsystem.py
@@ -192,6 +192,7 @@ class ModelSystem:
                 if purpose.dest != "source":
                     for mode in demand:
                         self.dtm.add_demand(demand[mode])
+                    for mode in purpose.modes:
                         self.travel_modes[mode] = True
             self.event_handler.on_purpose_demand_calculated(purpose, demand, pnr_iteration = pnr_it, estimation_mode=estimation_mode)
 
@@ -519,8 +520,9 @@ class AgentModelSystem(ModelSystem):
                     demand = purpose.calc_demand(estimation_mode)
                     if purpose.dest != "source":
                         for mode in demand:
-                            self.travel_modes[mode] = True
                             self.dtm.add_demand(demand[mode])
+                        for mode in purpose.modes:
+                            self.travel_modes[mode] = True
                 else:
                     for mode in purpose.modes:
                         self.travel_modes[mode] = True

--- a/Scripts/tests/integration/test_models.py
+++ b/Scripts/tests/integration/test_models.py
@@ -61,7 +61,7 @@ class ModelTest(unittest.TestCase):
         self._validate_impedances(impedance["iht"])
 
         # Check that model result does not change
-        self.assertAlmostEquals(model.mode_share[0]["car"], 0.21777550284903216)
+        self.assertAlmostEquals(model.mode_share[0]["car"], 0.21754170720172142)
         
         print("Model system test done")
     


### PR DESCRIPTION
This PR fixes bug in travel modes variable. Previously pnr_car and pnr_transit were searched for in purpose demand matrices, but purpose is still storing them as park_and_ride. 
Park and ride is also removed from the mode split that checks the whole model area in result summary. At that stage park and ride is already split in half (opposite of the previous problem).