### PR TITLE
Adjusted the read csv function so that it can read 2026 tco file

### DIFF
--- a/Scripts/tests/integration/test_data_handling.py
+++ b/Scripts/tests/integration/test_data_handling.py
@@ -102,5 +102,5 @@ class ZoneDataTest(unittest.TestCase):
         industry = df["industry"] # Let's pick a column and validate it
         expected_industry = pandas.Series(
             [3.3971, 579.7232, 2.1984, 467.7852, 29.4101, 2.1424, 7.392, 0, 0, 0],
-            index=INTERNAL_ZONES, dtype=numpy.float32, name="industry")
+            index=pandas.Index(INTERNAL_ZONES, name="zone"), dtype=numpy.float32, name="industry")
         pandas.testing.assert_series_equal(industry, expected_industry)

--- a/Scripts/utils/read_csv_file.py
+++ b/Scripts/utils/read_csv_file.py
@@ -83,7 +83,6 @@ def read_csv_file(data_dir: str,
             na_values="", comment='#', header=header)
     if squeeze:
         data = data.squeeze()
-    log.info(str(data))
     if pandas.api.types.is_numeric_dtype(data.index) and data.index.hasnans:
         msg = "Row with only spaces or tabs in file {}".format(path)
         log.error(msg)

--- a/Scripts/utils/read_csv_file.py
+++ b/Scripts/utils/read_csv_file.py
@@ -1,4 +1,5 @@
 import os
+import re
 from typing import Optional
 import pandas
 import numpy
@@ -46,11 +47,43 @@ def read_csv_file(data_dir: str,
         # This error should not be logged, as it is sometimes excepted
         raise NameError(msg)
     header: Optional[str] = None if squeeze else "infer"
-    data: pandas.DataFrame = pandas.read_csv(
-        path, sep='\s+', keep_default_na=False,
-        na_values="", comment='#', header=header)
+    if not squeeze:
+        with open(path, encoding="utf-8") as f:
+            for lineno, line in enumerate(f):
+                if line.strip() and not line.lstrip().startswith("#"):
+                    # Is first character of the line whitespace? 
+                    has_unnamed_first_column = line[0].isspace()
+
+                    # Works like sep=r"\s+": 
+                    header_cleaned = re.split(r"\s+", line.strip())
+
+                    if has_unnamed_first_column:
+                        header_cleaned.insert(0, "zone")
+
+                    break
+            else:
+                raise ValueError("File does not contain a header row")
+
+        header = header_cleaned
+        index_col = 0 if header and header[0] == "zone" else None
+        data = pandas.read_csv(
+            path,
+            sep='\s+',
+            skiprows=lineno + 1,   # ohita myös header-rivi
+            names=header,
+            header=None,
+            comment="#",
+            index_col=index_col,
+            keep_default_na=False,
+            na_values="",
+        )
+    else:
+        data: pandas.DataFrame = pandas.read_csv(
+            path, sep='\s+', keep_default_na=False,
+            na_values="", comment='#', header=header)
     if squeeze:
         data = data.squeeze()
+    log.info(str(data))
     if pandas.api.types.is_numeric_dtype(data.index) and data.index.hasnans:
         msg = "Row with only spaces or tabs in file {}".format(path)
         log.error(msg)


### PR DESCRIPTION
Adjusted the read csv function so that it can read tco file with empty third column while keeping the \s+ logic in the reading.
New tco file had no values for exclusive column which caused pandas "infer" method to interpret the header as two columns only, the first column has no name. 
Fix is manually composing the header in similar way to "infer" method, but it adds missing column in case the header starts tab or space. 
The practice with leading tabs is however not stable and some files even use two leading tabs, I believe our input files would deserve much greater overhaul than this small-ish hotfix. 
FYI @johpiip 