### PR TITLE
Fix/cba raise error for missing vehicles

### DIFF
--- a/Scripts/cba.py
+++ b/Scripts/cba.py
@@ -222,10 +222,11 @@ def run_cost_benefit_analysis(scenario_0, scenario_1, year, workbook):
     ws[CELL_INDICES["noise"][year]] = sum(noise_diff["population"])
 
     transit_vehicle_kms_tables = [read(TRANSIT_KMS_FILE, scenario_0), read(TRANSIT_KMS_FILE, scenario_1)]
-    for transit_vehicle_kms in transit_vehicle_kms_tables:
+    for i, transit_vehicle_kms in enumerate(transit_vehicle_kms_tables):
         missing_vehicle = False
+        log.debug(f"Transit vehicle mileages for scenario {scenario_0 if i == 0 else scenario_1}:")
         for vehicle, values in transit_vehicle_kms.iterrows():
-            log.debug(f"Transit vehicle {vehicle} has {values['dist']} kms")
+            log.debug(f"{vehicle} mileage:\t{values['dist']:.2f} km")
             if values['dist'] > 0 and vehicle not in {submode for submodes in TRANSIT_AGGREGATIONS.values() for submode in submodes}:
                 if vehicle not in missing_vehicle_whitelist:
                     log.error(f"Transit vehicle {vehicle} is used but is not included in the aggregation dictionary. Add the vehicle to the TRANSIT_AGGREGATIONS dictionary in cba.py")

--- a/Scripts/cba.py
+++ b/Scripts/cba.py
@@ -31,12 +31,14 @@ TRANSIT_AGGREGATIONS = {
     "trunk": ("HSL-runkob","nivelbussi"),
     "train": ("HSL-juna-2", "muu_juna", "HSL-juna-1", "HSL-juna-3"),
     "tram": ("ratikka", "pikaratikk"),
+    "metro": ("metro", ),
 }
 TRANSIT_AGGREGATIONS_FALLBACK = {
     "bus": ("HSL-bussi", "ValluVakio", "ValluPika"),
     "trunk": ("HSL-runkob", ),
     "train": ("HSL-juna", "muu_juna"),
     "tram": ("ratikka", "pikaratikk"),
+    "metro": ("metro", ),
 }
 
 TRANSLATIONS = {
@@ -196,6 +198,10 @@ def run_cost_benefit_analysis(scenario_0, scenario_1, year, workbook):
         Table of zone-wise consumer surplus results
         (travel time, travel cost, distance, revenue)
     """
+    # Vehicles that can be skipped for the aggregation check.
+    # Should be taken into account in special occasions, such as scenarios with major ferry traffic.
+    missing_vehicle_whitelist = ["lautta"]
+
     if year not in (1, 2):
         raise ValueError("Evaluation year must be either 1 or 2")
     log.info("Analyse year {}...".format(year))
@@ -217,6 +223,15 @@ def run_cost_benefit_analysis(scenario_0, scenario_1, year, workbook):
 
     transit_vehicle_kms_tables = [read(TRANSIT_KMS_FILE, scenario_0), read(TRANSIT_KMS_FILE, scenario_1)]
     for transit_vehicle_kms in transit_vehicle_kms_tables:
+        missing_vehicle = False
+        for vehicle, values in transit_vehicle_kms.iterrows():
+            log.debug(f"Transit vehicle {vehicle} has {values['dist']} kms")
+            if values['dist'] > 0 and vehicle not in {submode for submodes in TRANSIT_AGGREGATIONS.values() for submode in submodes}:
+                if vehicle not in missing_vehicle_whitelist:
+                    log.error(f"Transit vehicle {vehicle} is used but is not included in the aggregation dictionary. Add the vehicle to the TRANSIT_AGGREGATIONS dictionary in cba.py")
+                    missing_vehicle = True
+        if missing_vehicle:
+            raise KeyError("Missing transit vehicle(s) in TRANSIT_AGGREGATIONS dictionary. See log for details.")
         if all(submode in transit_vehicle_kms.index for submodes in TRANSIT_AGGREGATIONS.values() for submode in submodes):
             transit_aggs = TRANSIT_AGGREGATIONS
         else:


### PR DESCRIPTION
CBA run will now halt if there are vehicles with non-zero mileage that are ignored by CBA script.

Ferries or "lautta" is whitelisted and will not be taken into account, as it has not been. This should be fine for most scenarios, but might cause problems later if there are scenarios with major increases in HSL ferry traffic. Changes in demand will be calculated correctly, but operational costs are ignored.